### PR TITLE
Force top sticky slot

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ SUGGESTED_SORT - what do you want the suggested sort to be? ("confidence", "top"
 
 STICKY - do you want the thread stickied? (mod only)
 
+FORCETOPSTICKYSLOT - if using STICKY, do you want to force the sticky into the top sticky slot? otherwise it will default to the bottom sticky slot and could leave an old GDT in the top sticky slot until manually unstickied. 
+
 MESSAGE - send submission shortlink to /u/baseballbot
 
 PRE_THREAD_SETTINGS - what to include in the pregame threads

--- a/sample_settings.json
+++ b/sample_settings.json
@@ -11,6 +11,7 @@
     "PREGAME_THREAD": false,
     "POST_GAME_THREAD": false,
     "STICKY": true,
+    "FORCETOPSTICKYSLOT": false,
     "SUGGESTED_SORT": "new",
     "MESSAGE": false,
     "PRE_THREAD_SETTINGS": {

--- a/src/main.py
+++ b/src/main.py
@@ -31,6 +31,7 @@ class Bot:
         self.PREGAME_THREAD = None
         self.POST_GAME_THREAD = None
         self.STICKY = None
+        self.FORCETOPSTICKYSLOT = None
         self.SUGGESTED_SORT = None
         self.MESSAGE = None
         self.PRE_THREAD_SETTINGS = None
@@ -76,6 +77,11 @@ class Bot:
 
             self.STICKY = settings.get('STICKY')
             if self.STICKY == None: return "Missing STICKY"
+            
+            self.FORCETOPSTICKYSLOT = settings.get('FORCETOPSTICKYSLOT')
+            if self.FORCETOPSTICKYSLOT == None: return "Missing FORCETOPSTICKYSLOT"
+            if self.FORCETOPSTICKYSLOT: self.BOTTOMSTICKY = "bottom=False"
+            else: self.BOTTOMSTICKY = ""
 
             self.SUGGESTED_SORT = settings.get('SUGGESTED_SORT')
             if self.SUGGESTED_SORT == None: return "Missing SUGGESTED_SORT"
@@ -195,7 +201,7 @@ class Bot:
                             print "Pregame thread submitted..."
                             if self.STICKY:
                                 print "Stickying submission..."
-                                sub.sticky(bottom=False)
+                                sub.sticky(self.BOTTOMSTICKY)
                                 print "Submission stickied..."
                             print "Sleeping for two minutes..."
                             print datetime.strftime(datetime.today(), "%d %I:%M %p")
@@ -226,7 +232,7 @@ class Bot:
                                 print "Game thread submitted..."
                                 if self.STICKY:
                                     print "Stickying submission..."
-                                    sub.sticky(bottom=False)
+                                    sub.sticky(self.BOTTOMSTICKY)
                                     print "Submission stickied..."
                                 if self.SUGGESTED_SORT != None:
                                     print "Setting suggested sort to " + self.SUGGESTED_SORT + "..."
@@ -297,7 +303,7 @@ class Bot:
                                 print "Postgame thread submitted..."
                                 if self.STICKY:
                                     print "Stickying submission..."
-                                    sub.sticky(bottom=False)
+                                    sub.sticky(self.BOTTOMSTICKY)
                                     print "Submission stickied..."
                             break
                         time.sleep(10)

--- a/src/main.py
+++ b/src/main.py
@@ -80,8 +80,6 @@ class Bot:
             
             self.FORCETOPSTICKYSLOT = settings.get('FORCETOPSTICKYSLOT')
             if self.FORCETOPSTICKYSLOT == None: return "Missing FORCETOPSTICKYSLOT"
-            if self.FORCETOPSTICKYSLOT: self.BOTTOMSTICKY = "bottom=False"
-            else: self.BOTTOMSTICKY = ""
 
             self.SUGGESTED_SORT = settings.get('SUGGESTED_SORT')
             if self.SUGGESTED_SORT == None: return "Missing SUGGESTED_SORT"
@@ -201,7 +199,8 @@ class Bot:
                             print "Pregame thread submitted..."
                             if self.STICKY:
                                 print "Stickying submission..."
-                                sub.sticky(self.BOTTOMSTICKY)
+                                if self.FORCETOPSTICKYSLOT: sub.sticky(bottom=False)
+                                else: sub.sticky()
                                 print "Submission stickied..."
                             print "Sleeping for two minutes..."
                             print datetime.strftime(datetime.today(), "%d %I:%M %p")
@@ -232,7 +231,8 @@ class Bot:
                                 print "Game thread submitted..."
                                 if self.STICKY:
                                     print "Stickying submission..."
-                                    sub.sticky(self.BOTTOMSTICKY)
+                                    if self.FORCETOPSTICKYSLOT: sub.sticky(bottom=False)
+                                    else: sub.sticky()
                                     print "Submission stickied..."
                                 if self.SUGGESTED_SORT != None:
                                     print "Setting suggested sort to " + self.SUGGESTED_SORT + "..."
@@ -303,7 +303,8 @@ class Bot:
                                 print "Postgame thread submitted..."
                                 if self.STICKY:
                                     print "Stickying submission..."
-                                    sub.sticky(self.BOTTOMSTICKY)
+                                    if self.FORCETOPSTICKYSLOT: sub.sticky(bottom=False)
+                                    else: sub.sticky()
                                     print "Submission stickied..."
                             break
                         time.sleep(10)

--- a/src/main.py
+++ b/src/main.py
@@ -195,7 +195,7 @@ class Bot:
                             print "Pregame thread submitted..."
                             if self.STICKY:
                                 print "Stickying submission..."
-                                sub.sticky()
+                                sub.sticky(bottom=False)
                                 print "Submission stickied..."
                             print "Sleeping for two minutes..."
                             print datetime.strftime(datetime.today(), "%d %I:%M %p")
@@ -226,7 +226,7 @@ class Bot:
                                 print "Game thread submitted..."
                                 if self.STICKY:
                                     print "Stickying submission..."
-                                    sub.sticky()
+                                    sub.sticky(bottom=False)
                                     print "Submission stickied..."
                                 if self.SUGGESTED_SORT != None:
                                     print "Setting suggested sort to " + self.SUGGESTED_SORT + "..."
@@ -297,7 +297,7 @@ class Bot:
                                 print "Postgame thread submitted..."
                                 if self.STICKY:
                                     print "Stickying submission..."
-                                    sub.sticky()
+                                    sub.sticky(bottom=False)
                                     print "Submission stickied..."
                             break
                         time.sleep(10)


### PR DESCRIPTION
Since Reddit supports two sticky slots per sub, this option will be useful for subs that don't have a non-GDT sticky post. Without this option, or with this option set at the default (false), the first GDT posted as sticky will remain in the top sticky slot and subsequent GDTs will use/replace the bottom sticky slot. This results in a stale GDT being sticky until manually unstickied.

With this option set to true, the top GDT will always use the top sticky slot. Subs without a non-GDT sticky post can use this option to prevent stale sticky GDTs, and if they want to sticky a non-GDT post, they can do so in the bottom sticky slot and the GDT threads will continue to use the top sticky slot.
