### PR TITLE
Don't assume working directory

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -38,7 +38,9 @@ class Bot:
         self.POST_THREAD_SETTINGS = None
 
     def read_settings(self):
-        with open('settings.json') as data:
+        import os
+        cwd = os.path.dirname(os.path.realpath(__file__))
+        with open(cwd + '/settings.json') as data:
             settings = json.load(data)
 
             self.CLIENT_ID = settings.get('CLIENT_ID')


### PR DESCRIPTION
This change, as pointed out by @dgautsch in Issue #17 , allows the bot to be run from another directory. Of particular interest to me, this allows running of the bot as a startup task/cron job.
