### PR TITLE
Add baseball.theater link to highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ SUGGESTED_SORT - what do you want the suggested sort to be? ("confidence", "top"
 
 STICKY - do you want the thread stickied? (mod only)
 
+FORCETOPSTICKYSLOT - if using STICKY, do you want to force the sticky into the top sticky slot? otherwise it will default to the bottom sticky slot and could leave an old GDT in the top sticky slot until manually unstickied. 
+
 MESSAGE - send submission shortlink to /u/baseballbot
 
 PRE_THREAD_SETTINGS - what to include in the pregame threads

--- a/README.md
+++ b/README.md
@@ -47,13 +47,7 @@ To use the default settings, copy `sample_settings.json` into `src/settings.json
 
 * `STICKY` - do you want the thread stickied? (mod only)
 
-* `FORCETOPSTICKYSLOT` - if using STICKY, do you want to force the sticky into the top sticky slot? otherwise it will default to the bottom sticky slot and could leave an old GDT in the top sticky slot until manually unstickied. 
-
 * `MESSAGE` - send submission shortlink to /u/baseballbot
-
-* `INBOXREPLIES` - do you want to receive thread replies in the bot's inbox?
-
-* `WINLOSS_POST_THREAD_TAGS` - do you want to use different postgame thread tags for wins and losses? (configure in POST_THREAD_SETTINGS)
 
 * `PRE_THREAD_SETTINGS` - what to include in the pregame threads
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ STICKY - do you want the thread stickied? (mod only)
 
 MESSAGE - send submission shortlink to /u/baseballbot
 
+INBOXREPLIES - do you want to receive thread replies in the bot's inbox?
+
 PRE_THREAD_SETTINGS - what to include in the pregame threads
 
 THREAD_SETTINGS - what to include in game threads

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ STICKY - do you want the thread stickied? (mod only)
 
 MESSAGE - send submission shortlink to /u/baseballbot
 
+WINLOSS_POST_THREAD_TAGS - do you want to use different postgame thread tags for wins and losses? (configure in POST_THREAD_SETTINGS)
+
 PRE_THREAD_SETTINGS - what to include in the pregame threads
 
 THREAD_SETTINGS - what to include in game threads

--- a/sample_settings.json
+++ b/sample_settings.json
@@ -13,6 +13,7 @@
     "STICKY": true,
     "SUGGESTED_SORT": "new",
     "MESSAGE": false,
+    "WINLOSS_POST_THREAD_TAGS": false,
     "PRE_THREAD_SETTINGS": {
         "PRE_THREAD_TAG": "PREGAME THREAD:",
         "PRE_THREAD_TIME": "9AM",
@@ -34,6 +35,8 @@
     },
     "POST_THREAD_SETTINGS": {
         "POST_THREAD_TAG": "POST GAME THREAD:",
+        "POST_THREAD_WIN_TAG": "OUR TEAM WON:",
+        "POST_THREAD_LOSS_TAG": "OUR TEAM LOST:",
         "CONTENT": {
             "HEADER": true,
             "BOX_SCORE": true,

--- a/sample_settings.json
+++ b/sample_settings.json
@@ -13,8 +13,6 @@
     "STICKY": true,
     "SUGGESTED_SORT": "new",
     "MESSAGE": false,
-    "THEATER_LINK_GAME": false,
-    "THEATER_LINK_POST": false,
     "PRE_THREAD_SETTINGS": {
         "PRE_THREAD_TAG": "PREGAME THREAD:",
         "PRE_THREAD_TIME": "9AM",
@@ -31,6 +29,7 @@
             "LINE_SCORE": true,
             "SCORING_PLAYS": true,
             "HIGHLIGHTS": true,
+            "THEATER_LINK_GAME": false,
             "FOOTER": false
         }
     },
@@ -42,6 +41,7 @@
             "LINE_SCORE": true,
             "SCORING_PLAYS": true,
             "HIGHLIGHTS": true,
+            "THEATER_LINK_POST": false,
             "FOOTER": false
         }
     }

--- a/sample_settings.json
+++ b/sample_settings.json
@@ -13,7 +13,8 @@
     "STICKY": true,
     "SUGGESTED_SORT": "new",
     "MESSAGE": false,
-    "THEATER_LINK": false,
+    "THEATER_LINK_GAME": false,
+    "THEATER_LINK_POST": false,
     "PRE_THREAD_SETTINGS": {
         "PRE_THREAD_TAG": "PREGAME THREAD:",
         "PRE_THREAD_TIME": "9AM",

--- a/sample_settings.json
+++ b/sample_settings.json
@@ -13,6 +13,7 @@
     "STICKY": true,
     "SUGGESTED_SORT": "new",
     "MESSAGE": false,
+    "INBOXREPLIES": false,
     "PRE_THREAD_SETTINGS": {
         "PRE_THREAD_TAG": "PREGAME THREAD:",
         "PRE_THREAD_TIME": "9AM",

--- a/sample_settings.json
+++ b/sample_settings.json
@@ -29,8 +29,8 @@
             "LINE_SCORE": true,
             "SCORING_PLAYS": true,
             "HIGHLIGHTS": true,
-            "THEATER_LINK_GAME": false,
-            "FOOTER": false
+            "FOOTER": false,
+            "THEATER_LINK": false
         }
     },
     "POST_THREAD_SETTINGS": {
@@ -41,8 +41,8 @@
             "LINE_SCORE": true,
             "SCORING_PLAYS": true,
             "HIGHLIGHTS": true,
-            "THEATER_LINK_POST": false,
-            "FOOTER": false
+            "FOOTER": false,
+            "THEATER_LINK": false
         }
     }
 }

--- a/sample_settings.json
+++ b/sample_settings.json
@@ -13,6 +13,7 @@
     "STICKY": true,
     "SUGGESTED_SORT": "new",
     "MESSAGE": false,
+    "THEATER_LINK": false,
     "PRE_THREAD_SETTINGS": {
         "PRE_THREAD_TAG": "PREGAME THREAD:",
         "PRE_THREAD_TIME": "9AM",

--- a/sample_settings.json
+++ b/sample_settings.json
@@ -11,12 +11,8 @@
     "PREGAME_THREAD": false,
     "POST_GAME_THREAD": false,
     "STICKY": true,
-    "FORCETOPSTICKYSLOT": false,
     "SUGGESTED_SORT": "new",
     "MESSAGE": false,
-    "INBOXREPLIES": false,
-    "WINLOSS_POST_THREAD_TAGS": false,
-
     "PRE_THREAD_SETTINGS": {
         "PRE_THREAD_TAG": "PREGAME THREAD:",
         "PRE_THREAD_TIME": "9AM",
@@ -39,8 +35,6 @@
     },
     "POST_THREAD_SETTINGS": {
         "POST_THREAD_TAG": "POST GAME THREAD:",
-        "POST_THREAD_WIN_TAG": "OUR TEAM WON:",
-        "POST_THREAD_LOSS_TAG": "OUR TEAM LOST:",
         "CONTENT": {
             "HEADER": true,
             "BOX_SCORE": true,

--- a/sample_settings.json
+++ b/sample_settings.json
@@ -11,6 +11,7 @@
     "PREGAME_THREAD": false,
     "POST_GAME_THREAD": false,
     "STICKY": true,
+    "FORCETOPSTICKYSLOT": false,
     "SUGGESTED_SORT": "new",
     "MESSAGE": false,
     "PRE_THREAD_SETTINGS": {

--- a/src/editor.py
+++ b/src/editor.py
@@ -53,7 +53,7 @@ class Editor:
 
     def generate_pre_code(self,dirs):
         code = ""
-	for d in dirs:
+        for d in dirs:
             temp_dirs = []
             temp_dirs.append(d + "linescore.json")
             temp_dirs.append(d + "gamecenter.xml")

--- a/src/editor.py
+++ b/src/editor.py
@@ -134,7 +134,7 @@ class Editor:
             return first_pitch
 
 
-    def generate_code(self,dir,thread,theater_link=False):
+    def generate_code(self,dir,thread,myteam="",theater_link=False):
         code = ""
         dirs = []
         dirs.append(dir + "linescore.json")
@@ -149,14 +149,14 @@ class Editor:
             if self.box_score: code = code + self.generate_boxscore(files)
             if self.line_score: code = code + self.generate_linescore(files)
             if self.scoring_plays: code = code + self.generate_scoring_plays(files)
-            if self.highlights: code = code + self.generate_highlights(files,theater_link)
+            if self.highlights: code = code + self.generate_highlights(files,myteam,theater_link)
             if self.footer: code = code + self.generate_footer()
         elif thread == "post":
             if self.post_header: code = code + self.generate_header(files)
             if self.post_box_score: code = code + self.generate_boxscore(files)
             if self.post_line_score: code = code + self.generate_linescore(files)
             if self.post_scoring_plays: code = code + self.generate_scoring_plays(files)
-            if self.post_highlights: code = code + self.generate_highlights(files,theater_link)
+            if self.post_highlights: code = code + self.generate_highlights(files,myteam,theater_link)
             if self.post_footer: code = code + self.generate_footer()
         code = code + self.generate_status(files)
         print "Returning all code..."

--- a/src/editor.py
+++ b/src/editor.py
@@ -134,7 +134,7 @@ class Editor:
             return first_pitch
 
 
-    def generate_code(self,dir,thread,myteam=""):
+    def generate_code(self,dir,thread):
         code = ""
         dirs = []
         dirs.append(dir + "linescore.json")
@@ -149,14 +149,14 @@ class Editor:
             if self.box_score: code = code + self.generate_boxscore(files)
             if self.line_score: code = code + self.generate_linescore(files)
             if self.scoring_plays: code = code + self.generate_scoring_plays(files)
-            if self.highlights: code = code + self.generate_highlights(files,myteam,self.theater_link)
+            if self.highlights: code = code + self.generate_highlights(files,self.theater_link)
             if self.footer: code = code + self.generate_footer()
         elif thread == "post":
             if self.post_header: code = code + self.generate_header(files)
             if self.post_box_score: code = code + self.generate_boxscore(files)
             if self.post_line_score: code = code + self.generate_linescore(files)
             if self.post_scoring_plays: code = code + self.generate_scoring_plays(files)
-            if self.post_highlights: code = code + self.generate_highlights(files,myteam,self.post_theater_link)
+            if self.post_highlights: code = code + self.generate_highlights(files,self.post_theater_link)
             if self.post_footer: code = code + self.generate_footer()
         code = code + self.generate_status(files)
         print "Returning all code..."
@@ -418,7 +418,7 @@ class Editor:
             return scoringplays
 
 
-    def generate_highlights(self,files,myteam="",theater_link=False):
+    def generate_highlights(self,files,theater_link=False):
         highlight = ""
         try:
             root = files["highlights"].getroot()
@@ -432,7 +432,10 @@ class Editor:
                         highlight = highlight + "|" + team[0] + "|[" + v.find("headline").text + "](" + v.find("url").text + ")|\n"                   
                     except:
                         highlight = highlight + "|[](/MLB)|[" + v.find("headline").text + "](" + v.find("url").text + ")|\n"                     
-            if theater_link: highlight = highlight + "||See all highlights at [Baseball.Theater](http://baseball.theater/team/" + myteam + "/game/" + datetime.now().strftime('%Y%m%d') + ")|\n"
+            if theater_link:
+                game = files["linescore"].get('data').get('game')
+                notes = self.get_notes(game.get('home_team_name'), game.get('away_team_name'))
+                highlight = highlight + "||See all highlights at [Baseball.Theater](http://baseball.theater/team/" + notes[0] + "/game/" + datetime.now().strftime('%Y%m%d') + ")|\n"
             highlight = highlight + "\n\n"
             print "Returning highlight..."
             return highlight

--- a/src/editor.py
+++ b/src/editor.py
@@ -134,7 +134,7 @@ class Editor:
             return first_pitch
 
 
-    def generate_code(self,dir,thread):
+    def generate_code(self,dir,thread,theater_link=False):
         code = ""
         dirs = []
         dirs.append(dir + "linescore.json")
@@ -149,14 +149,14 @@ class Editor:
             if self.box_score: code = code + self.generate_boxscore(files)
             if self.line_score: code = code + self.generate_linescore(files)
             if self.scoring_plays: code = code + self.generate_scoring_plays(files)
-            if self.highlights: code = code + self.generate_highlights(files)
+            if self.highlights: code = code + self.generate_highlights(files,theater_link)
             if self.footer: code = code + self.generate_footer()
         elif thread == "post":
             if self.post_header: code = code + self.generate_header(files)
             if self.post_box_score: code = code + self.generate_boxscore(files)
             if self.post_line_score: code = code + self.generate_linescore(files)
             if self.post_scoring_plays: code = code + self.generate_scoring_plays(files)
-            if self.post_highlights: code = code + self.generate_highlights(files)
+            if self.post_highlights: code = code + self.generate_highlights(files,theater_link)
             if self.post_footer: code = code + self.generate_footer()
         code = code + self.generate_status(files)
         print "Returning all code..."
@@ -418,7 +418,7 @@ class Editor:
             return scoringplays
 
 
-    def generate_highlights(self,files):
+    def generate_highlights(self,files,theater_link=False):
         highlight = ""
         try:
             root = files["highlights"].getroot()
@@ -432,6 +432,7 @@ class Editor:
                         highlight = highlight + "|" + team[0] + "|[" + v.find("headline").text + "](" + v.find("url").text + ")|\n"                   
                     except:
                         highlight = highlight + "|[](/MLB)|[" + v.find("headline").text + "](" + v.find("url").text + ")|\n"                     
+            if theater_link: highlight = highlight + "See more at [Baseball.Theater](http://baseball.theater)\n"
             highlight = highlight + "\n\n"
             print "Returning highlight..."
             return highlight

--- a/src/editor.py
+++ b/src/editor.py
@@ -432,7 +432,7 @@ class Editor:
                         highlight = highlight + "|" + team[0] + "|[" + v.find("headline").text + "](" + v.find("url").text + ")|\n"                   
                     except:
                         highlight = highlight + "|[](/MLB)|[" + v.find("headline").text + "](" + v.find("url").text + ")|\n"                     
-            if theater_link: highlight = highlight + "|:--|See more at [Baseball.Theater](http://baseball.theater/team/" + v.get('team_id')/ + "game/" + datetime.datetime.today().strftime('%Y%m%d') + ")|\n"
+            if theater_link: highlight = highlight + "|:--|See more at [Baseball.Theater](http://baseball.theater/team/" + v.get('team_id') + "/game/" + datetime.datetime.today().strftime('%Y%m%d') + ")|\n"
             highlight = highlight + "\n\n"
             print "Returning highlight..."
             return highlight

--- a/src/editor.py
+++ b/src/editor.py
@@ -19,12 +19,12 @@ class Editor:
         (self.thread_tag, 
             (self.header, self.box_score, 
              self.line_score, self.scoring_plays,
-             self.highlights, self.footer)
+             self.highlights, self.footer, self.theater_link)
         ) = thread_settings
         (self.post_thread_tag, 
             (self.post_header, self.post_box_score, 
              self.post_line_score, self.post_scoring_plays,
-             self.post_highlights, self.post_footer)
+             self.post_highlights, self.post_footer, self.post_theater_link)
         ) = post_thread_settings
 
 
@@ -149,14 +149,14 @@ class Editor:
             if self.box_score: code = code + self.generate_boxscore(files)
             if self.line_score: code = code + self.generate_linescore(files)
             if self.scoring_plays: code = code + self.generate_scoring_plays(files)
-            if self.highlights: code = code + self.generate_highlights(files,myteam,theater_link)
+            if self.highlights: code = code + self.generate_highlights(files,myteam,self.theater_link)
             if self.footer: code = code + self.generate_footer()
         elif thread == "post":
             if self.post_header: code = code + self.generate_header(files)
             if self.post_box_score: code = code + self.generate_boxscore(files)
             if self.post_line_score: code = code + self.generate_linescore(files)
             if self.post_scoring_plays: code = code + self.generate_scoring_plays(files)
-            if self.post_highlights: code = code + self.generate_highlights(files,myteam,theater_link)
+            if self.post_highlights: code = code + self.generate_highlights(files,myteam,self.post_theater_link)
             if self.post_footer: code = code + self.generate_footer()
         code = code + self.generate_status(files)
         print "Returning all code..."

--- a/src/editor.py
+++ b/src/editor.py
@@ -432,7 +432,7 @@ class Editor:
                         highlight = highlight + "|" + team[0] + "|[" + v.find("headline").text + "](" + v.find("url").text + ")|\n"                   
                     except:
                         highlight = highlight + "|[](/MLB)|[" + v.find("headline").text + "](" + v.find("url").text + ")|\n"                     
-            if theater_link: highlight = highlight + "See more at [Baseball.Theater](http://baseball.theater)\n"
+            if theater_link: highlight = highlight + "|:--|See more at [Baseball.Theater](http://baseball.theater/team/" + v.get('team_id')/ + "game/" + datetime.datetime.today().strftime('%Y%m%d') + ")|\n"
             highlight = highlight + "\n\n"
             print "Returning highlight..."
             return highlight

--- a/src/editor.py
+++ b/src/editor.py
@@ -21,27 +21,17 @@ class Editor:
              self.line_score, self.scoring_plays,
              self.highlights, self.footer, self.theater_link)
         ) = thread_settings
-        (self.post_thread_tag, self.post_thread_win_tag, self.post_thread_loss_tag,
+        (self.post_thread_tag, 
             (self.post_header, self.post_box_score, 
              self.post_line_score, self.post_scoring_plays,
              self.post_highlights, self.post_footer, self.post_theater_link)
         ) = post_thread_settings
 
 
-    def generate_title(self,dir,thread,includewinloss=False,myteam=""):
+    def generate_title(self,dir,thread):
         if thread == "pre": title = self.pre_thread_tag + " "
         elif thread == "game": title = self.thread_tag + " "
-        elif thread == "post":
-            if includewinloss:
-                myteamwon = ""
-                myteamwon = self.didmyteamwin(dir, myteam)
-                if myteamwon == "0":
-                    title = self.post_thread_loss_tag + " "
-                elif myteamwon == "1":
-                    title = self.post_thread_win_tag + " "
-                else:
-                    title = self.post_thread_tag + " "
-            else: title = self.post_thread_tag + " "
+        elif thread == "post": title = self.post_thread_tag + " "
         while True:
             try:
                 response = urllib2.urlopen(dir + "linescore.json")
@@ -144,7 +134,7 @@ class Editor:
             return first_pitch
 
 
-    def generate_code(self,dir,thread,myteam=""):
+    def generate_code(self,dir,thread):
         code = ""
         dirs = []
         dirs.append(dir + "linescore.json")
@@ -414,9 +404,9 @@ class Editor:
 
                 scoringplays = scoringplays + "|"
                 if int(s.get("home")) < int(s.get("away")):
-                    scoringplays = scoringplays + s.get("away") + "-" + s.get("home") + " " + root.get("away_team").upper()
+                    scoringplays = scoringplays + s.get("away") + "-" + s.get("home")
                 elif int(s.get("home")) > int(s.get("away")):
-                    scoringplays = scoringplays + s.get("home") + "-" + s.get("away") + " " + root.get("home_team").upper()
+                    scoringplays = scoringplays + s.get("home") + "-" + s.get("away")
                 else:
                     scoringplays = scoringplays + s.get("home") + "-" + s.get("away")
                 scoringplays = scoringplays + "\n"
@@ -555,57 +545,6 @@ class Editor:
         except:
             print "Missing data for status, returning blank text..."
             return status
-
-    def didmyteamwin(self, dir, myteam):
-    #returns 0 for loss, 1 for win, 2 for tie, 3 for postponed/suspended/canceled, blank for exception
-        myteamwon = ""
-        myteamis = ""
-        dirs = []
-        dirs.append(dir + "linescore.json")
-        dirs.append(dir + "boxscore.json")
-        dirs.append(dir + "gamecenter.xml")
-        dirs.append(dir + "plays.json")
-        dirs.append(dir + "/inning/inning_Scores.xml")
-        dirs.append(dir + "/media/mobile.xml")
-        files = self.download_files(dirs)
-        game = files["linescore"].get('data').get('game')
-
-        if game.get('home_code') == myteam:
-            myteamis = "home"
-        elif game.get('away_code') == myteam:
-            myteamis = "away"
-        else:
-            print "Cannot determine if my team is home or away, returning blank text for whether my team won..."
-            return myteamwon
-        if game.get('status') == "Game Over" or game.get('status') == "Final" or game.get('status') == "Completed Early":
-            s = files["linescore"].get('data').get('game')
-            hometeamruns = int(s.get("home_team_runs"))
-            awayteamruns = int(s.get("away_team_runs"))
-            if int(hometeamruns == awayteamruns):
-                myteamwon = "2"
-                print "Returning whether my team won (TIE)..."
-                return myteamwon
-            else:
-                if hometeamruns < awayteamruns:
-                    if myteamis == "home":
-                        myteamwon = "0"
-                    elif myteamis == "away":
-                        myteamwon = "1"
-                    print "Returning whether my team won..."
-                    return myteamwon
-                elif hometeamruns > awayteamruns:
-                    if myteamis == "home":
-                        myteamwon = "1"
-                    elif myteamis == "away":
-                        myteamwon = "0"
-                    print "Returning whether my team won..."
-                    return myteamwon
-        elif game.get('status') == "Postponed" or game.get('status') == "Suspended" or game.get('status') == "Cancelled":
-            myteamwon = "3"
-            print "Returning whether my team won (postponed, suspended, or canceled)..."
-            return myteamwon
-        print "Returning whether my team won (exception)..." + myteamwon
-        return myteamwon
 
     def generate_footer(self):
         footer = ""

--- a/src/editor.py
+++ b/src/editor.py
@@ -432,7 +432,7 @@ class Editor:
                         highlight = highlight + "|" + team[0] + "|[" + v.find("headline").text + "](" + v.find("url").text + ")|\n"                   
                     except:
                         highlight = highlight + "|[](/MLB)|[" + v.find("headline").text + "](" + v.find("url").text + ")|\n"                     
-            if theater_link: highlight = highlight + "|:--|See more at [Baseball.Theater](http://baseball.theater/team/" + myteam + "/game/" + datetime.datetime.today().strftime('%Y%m%d') + ")|\n"
+            if theater_link: highlight = highlight + "|:--|See all highlights at [Baseball.Theater](http://baseball.theater/team/" + myteam + "/game/" + datetime.datetime.today().strftime('%Y%m%d') + ")|\n"
             highlight = highlight + "\n\n"
             print "Returning highlight..."
             return highlight

--- a/src/editor.py
+++ b/src/editor.py
@@ -404,9 +404,9 @@ class Editor:
 
                 scoringplays = scoringplays + "|"
                 if int(s.get("home")) < int(s.get("away")):
-                    scoringplays = scoringplays + s.get("away") + "-" + s.get("home")
+                    scoringplays = scoringplays + s.get("away") + "-" + s.get("home") + " " + root.get("away_team").upper()
                 elif int(s.get("home")) > int(s.get("away")):
-                    scoringplays = scoringplays + s.get("home") + "-" + s.get("away")
+                    scoringplays = scoringplays + s.get("home") + "-" + s.get("away") + " " + root.get("home_team").upper()
                 else:
                     scoringplays = scoringplays + s.get("home") + "-" + s.get("away")
                 scoringplays = scoringplays + "\n"

--- a/src/editor.py
+++ b/src/editor.py
@@ -419,6 +419,7 @@ class Editor:
 
 
     def generate_highlights(self,files,myteam="",theater_link=False):
+        import datetime
         highlight = ""
         try:
             root = files["highlights"].getroot()
@@ -432,7 +433,7 @@ class Editor:
                         highlight = highlight + "|" + team[0] + "|[" + v.find("headline").text + "](" + v.find("url").text + ")|\n"                   
                     except:
                         highlight = highlight + "|[](/MLB)|[" + v.find("headline").text + "](" + v.find("url").text + ")|\n"                     
-            if theater_link: highlight = highlight + "|:--|See all highlights at [Baseball.Theater](http://baseball.theater/team/" + myteam + "/game/" + datetime.datetime.today().strftime('%Y%m%d') + ")|\n"
+            if theater_link: highlight = highlight + "||See all highlights at [Baseball.Theater](http://baseball.theater/team/" + myteam + "/game/" + datetime.datetime.now().strftime('%Y%m%d') + ")|\n"
             highlight = highlight + "\n\n"
             print "Returning highlight..."
             return highlight

--- a/src/editor.py
+++ b/src/editor.py
@@ -418,7 +418,7 @@ class Editor:
             return scoringplays
 
 
-    def generate_highlights(self,files,theater_link=False):
+    def generate_highlights(self,files,myteam="",theater_link=False):
         highlight = ""
         try:
             root = files["highlights"].getroot()
@@ -432,7 +432,7 @@ class Editor:
                         highlight = highlight + "|" + team[0] + "|[" + v.find("headline").text + "](" + v.find("url").text + ")|\n"                   
                     except:
                         highlight = highlight + "|[](/MLB)|[" + v.find("headline").text + "](" + v.find("url").text + ")|\n"                     
-            if theater_link: highlight = highlight + "|:--|See more at [Baseball.Theater](http://baseball.theater/team/" + v.get('team_id') + "/game/" + datetime.datetime.today().strftime('%Y%m%d') + ")|\n"
+            if theater_link: highlight = highlight + "|:--|See more at [Baseball.Theater](http://baseball.theater/team/" + myteam + "/game/" + datetime.datetime.today().strftime('%Y%m%d') + ")|\n"
             highlight = highlight + "\n\n"
             print "Returning highlight..."
             return highlight

--- a/src/editor.py
+++ b/src/editor.py
@@ -21,17 +21,27 @@ class Editor:
              self.line_score, self.scoring_plays,
              self.highlights, self.footer)
         ) = thread_settings
-        (self.post_thread_tag, 
+        (self.post_thread_tag, self.post_thread_win_tag, self.post_thread_loss_tag,
             (self.post_header, self.post_box_score, 
              self.post_line_score, self.post_scoring_plays,
              self.post_highlights, self.post_footer)
         ) = post_thread_settings
 
 
-    def generate_title(self,dir,thread):
+    def generate_title(self,dir,thread,includewinloss=False,myteam=""):
         if thread == "pre": title = self.pre_thread_tag + " "
         elif thread == "game": title = self.thread_tag + " "
-        elif thread == "post": title = self.post_thread_tag + " "
+        elif thread == "post":
+            if includewinloss:
+                myteamwon = ""
+                myteamwon = self.didmyteamwin(dir, myteam)
+                if myteamwon == "0":
+                    title = self.post_thread_loss_tag + " "
+                elif myteamwon == "1":
+                    title = self.post_thread_win_tag + " "
+                else:
+                    title = self.post_thread_tag + " "
+            else: title = self.post_thread_tag + " "
         while True:
             try:
                 response = urllib2.urlopen(dir + "linescore.json")
@@ -541,6 +551,57 @@ class Editor:
         except:
             print "Missing data for status, returning blank text..."
             return status
+
+    def didmyteamwin(self, dir, myteam):
+    #returns 0 for loss, 1 for win, 2 for tie, 3 for postponed/suspended/canceled, blank for exception
+        myteamwon = ""
+        myteamis = ""
+        dirs = []
+        dirs.append(dir + "linescore.json")
+        dirs.append(dir + "boxscore.json")
+        dirs.append(dir + "gamecenter.xml")
+        dirs.append(dir + "plays.json")
+        dirs.append(dir + "/inning/inning_Scores.xml")
+        dirs.append(dir + "/media/mobile.xml")
+        files = self.download_files(dirs)
+        game = files["linescore"].get('data').get('game')
+
+        if game.get('home_code') == myteam:
+            myteamis = "home"
+        elif game.get('away_code') == myteam:
+            myteamis = "away"
+        else:
+            print "Cannot determine if my team is home or away, returning blank text for whether my team won..."
+            return myteamwon
+        if game.get('status') == "Game Over" or game.get('status') == "Final" or game.get('status') == "Completed Early":
+            s = files["linescore"].get('data').get('game')
+            hometeamruns = int(s.get("home_team_runs"))
+            awayteamruns = int(s.get("away_team_runs"))
+            if int(hometeamruns == awayteamruns):
+                myteamwon = "2"
+                print "Returning whether my team won (TIE)..."
+                return myteamwon
+            else:
+                if hometeamruns < awayteamruns:
+                    if myteamis == "home":
+                        myteamwon = "0"
+                    elif myteamis == "away":
+                        myteamwon = "1"
+                    print "Returning whether my team won..."
+                    return myteamwon
+                elif hometeamruns > awayteamruns:
+                    if myteamis == "home":
+                        myteamwon = "1"
+                    elif myteamis == "away":
+                        myteamwon = "0"
+                    print "Returning whether my team won..."
+                    return myteamwon
+        elif game.get('status') == "Postponed" or game.get('status') == "Suspended" or game.get('status') == "Cancelled":
+            myteamwon = "3"
+            print "Returning whether my team won (postponed, suspended, or canceled)..."
+            return myteamwon
+        print "Returning whether my team won (exception)..." + myteamwon
+        return myteamwon
 
     def generate_footer(self):
         footer = ""

--- a/src/editor.py
+++ b/src/editor.py
@@ -134,7 +134,7 @@ class Editor:
             return first_pitch
 
 
-    def generate_code(self,dir,thread,myteam="",theater_link=False):
+    def generate_code(self,dir,thread,myteam=""):
         code = ""
         dirs = []
         dirs.append(dir + "linescore.json")

--- a/src/editor.py
+++ b/src/editor.py
@@ -53,7 +53,7 @@ class Editor:
 
     def generate_pre_code(self,dirs):
         code = ""
-        for d in dirs:
+	for d in dirs:
             temp_dirs = []
             temp_dirs.append(d + "linescore.json")
             temp_dirs.append(d + "gamecenter.xml")

--- a/src/editor.py
+++ b/src/editor.py
@@ -419,7 +419,6 @@ class Editor:
 
 
     def generate_highlights(self,files,myteam="",theater_link=False):
-        import datetime
         highlight = ""
         try:
             root = files["highlights"].getroot()
@@ -433,7 +432,7 @@ class Editor:
                         highlight = highlight + "|" + team[0] + "|[" + v.find("headline").text + "](" + v.find("url").text + ")|\n"                   
                     except:
                         highlight = highlight + "|[](/MLB)|[" + v.find("headline").text + "](" + v.find("url").text + ")|\n"                     
-            if theater_link: highlight = highlight + "||See all highlights at [Baseball.Theater](http://baseball.theater/team/" + myteam + "/game/" + datetime.datetime.now().strftime('%Y%m%d') + ")|\n"
+            if theater_link: highlight = highlight + "||See all highlights at [Baseball.Theater](http://baseball.theater/team/" + myteam + "/game/" + datetime.now().strftime('%Y%m%d') + ")|\n"
             highlight = highlight + "\n\n"
             print "Returning highlight..."
             return highlight

--- a/src/main.py
+++ b/src/main.py
@@ -35,6 +35,7 @@ class Bot:
         self.STICKY = None
         self.SUGGESTED_SORT = None
         self.MESSAGE = None
+        self.THEATER_LINK = None
         self.PRE_THREAD_SETTINGS = None
         self.THREAD_SETTINGS = None
         self.POST_THREAD_SETTINGS = None
@@ -87,6 +88,9 @@ class Bot:
             self.MESSAGE = settings.get('MESSAGE')
             if self.MESSAGE == None: return "Missing MESSAGE"
 
+            self.THEATER_LINK = settings.get('THEATER_LINK')
+            if self.THEATER_LINK == None: return "Missing THEATER_LINK"
+            
             temp_settings = settings.get('PRE_THREAD_SETTINGS')
             content_settings = temp_settings.get('CONTENT')
             self.PRE_THREAD_SETTINGS = (temp_settings.get('PRE_THREAD_TAG'),temp_settings.get('PRE_THREAD_TIME'),

--- a/src/main.py
+++ b/src/main.py
@@ -86,7 +86,7 @@ class Bot:
 
             self.MESSAGE = settings.get('MESSAGE')
             if self.MESSAGE == None: return "Missing MESSAGE"
-            
+
             temp_settings = settings.get('PRE_THREAD_SETTINGS')
             content_settings = temp_settings.get('CONTENT')
             self.PRE_THREAD_SETTINGS = (temp_settings.get('PRE_THREAD_TAG'),temp_settings.get('PRE_THREAD_TIME'),

--- a/src/main.py
+++ b/src/main.py
@@ -86,9 +86,6 @@ class Bot:
 
             self.MESSAGE = settings.get('MESSAGE')
             if self.MESSAGE == None: return "Missing MESSAGE"
-
-            self.THEATER_LINK = settings.get('THEATER_LINK')
-            if self.THEATER_LINK == None: return "Missing THEATER_LINK"
             
             temp_settings = settings.get('PRE_THREAD_SETTINGS')
             content_settings = temp_settings.get('CONTENT')

--- a/src/main.py
+++ b/src/main.py
@@ -33,6 +33,7 @@ class Bot:
         self.STICKY = None
         self.SUGGESTED_SORT = None
         self.MESSAGE = None
+        self.WINLOSS_POST_THREAD_TAGS = None
         self.PRE_THREAD_SETTINGS = None
         self.THREAD_SETTINGS = None
         self.POST_THREAD_SETTINGS = None
@@ -101,12 +102,15 @@ class Bot:
 
             temp_settings = settings.get('POST_THREAD_SETTINGS')
             content_settings = temp_settings.get('CONTENT')
-            self.POST_THREAD_SETTINGS = (temp_settings.get('POST_THREAD_TAG'),
+            self.POST_THREAD_SETTINGS = (temp_settings.get('POST_THREAD_TAG'), temp_settings.get('POST_THREAD_WIN_TAG'), temp_settings.get('POST_THREAD_LOSS_TAG'),
                                     (content_settings.get('HEADER'), content_settings.get('BOX_SCORE'),
                                      content_settings.get('LINE_SCORE'), content_settings.get('SCORING_PLAYS'),
                                      content_settings.get('HIGHLIGHTS'), content_settings.get('FOOTER'))
                                  )
             if self.POST_THREAD_SETTINGS == None: return "Missing POST_THREAD_SETTINGS"
+
+            self.WINLOSS_POST_THREAD_TAGS = settings.get('WINLOSS_POST_THREAD_TAGS')
+            if self.WINLOSS_POST_THREAD_TAGS == None: return "Missing WINLOSS_POST_THREAD_TAGS"
 
         return 0
 
@@ -292,7 +296,7 @@ class Bot:
                         if pgt_submit:
                             if self.POST_GAME_THREAD:
                                 print "Submitting postgame thread..."
-                                posttitle = edit.generate_title(d,"post")
+                                posttitle = edit.generate_title(d,"post",self.WINLOSS_POST_THREAD_TAGS,self.TEAM_CODE)
                                 sub = r.submit(self.SUBREDDIT, posttitle, edit.generate_code(d,"post"))
                                 print "Postgame thread submitted..."
                                 if self.STICKY:

--- a/src/main.py
+++ b/src/main.py
@@ -33,11 +33,8 @@ class Bot:
         self.PREGAME_THREAD = None
         self.POST_GAME_THREAD = None
         self.STICKY = None
-        self.FORCETOPSTICKYSLOT = None
         self.SUGGESTED_SORT = None
         self.MESSAGE = None
-        self.INBOXREPLIES = None
-        self.WINLOSS_POST_THREAD_TAGS = None
         self.PRE_THREAD_SETTINGS = None
         self.THREAD_SETTINGS = None
         self.POST_THREAD_SETTINGS = None
@@ -83,18 +80,12 @@ class Bot:
 
             self.STICKY = settings.get('STICKY')
             if self.STICKY == None: return "Missing STICKY"
-            
-            self.FORCETOPSTICKYSLOT = settings.get('FORCETOPSTICKYSLOT')
-            if self.FORCETOPSTICKYSLOT == None: return "Missing FORCETOPSTICKYSLOT"
 
             self.SUGGESTED_SORT = settings.get('SUGGESTED_SORT')
             if self.SUGGESTED_SORT == None: return "Missing SUGGESTED_SORT"
 
             self.MESSAGE = settings.get('MESSAGE')
             if self.MESSAGE == None: return "Missing MESSAGE"
-
-            self.INBOXREPLIES = settings.get('INBOXREPLIES')
-            if self.INBOXREPLIES == None: return "Missing INBOXREPLIES"
 
             temp_settings = settings.get('PRE_THREAD_SETTINGS')
             content_settings = temp_settings.get('CONTENT')
@@ -114,15 +105,12 @@ class Bot:
 
             temp_settings = settings.get('POST_THREAD_SETTINGS')
             content_settings = temp_settings.get('CONTENT')
-            self.POST_THREAD_SETTINGS = (temp_settings.get('POST_THREAD_TAG'), temp_settings.get('POST_THREAD_WIN_TAG'), temp_settings.get('POST_THREAD_LOSS_TAG'),
+            self.POST_THREAD_SETTINGS = (temp_settings.get('POST_THREAD_TAG'),
                                     (content_settings.get('HEADER'), content_settings.get('BOX_SCORE'),
                                      content_settings.get('LINE_SCORE'), content_settings.get('SCORING_PLAYS'),
                                      content_settings.get('HIGHLIGHTS'), content_settings.get('FOOTER'), content_settings.get('THEATER_LINK'))
                                  )
             if self.POST_THREAD_SETTINGS == None: return "Missing POST_THREAD_SETTINGS"
-
-            self.WINLOSS_POST_THREAD_TAGS = settings.get('WINLOSS_POST_THREAD_TAGS')
-            if self.WINLOSS_POST_THREAD_TAGS == None: return "Missing WINLOSS_POST_THREAD_TAGS"
 
         return 0
 
@@ -209,17 +197,12 @@ class Bot:
                             print "Submitting pregame thread..."
                             if self.STICKY and 'sub' in locals():
                                 sub.unsticky()
-                            sub = r.submit(self.SUBREDDIT, title, edit.generate_pre_code(directories), send_replies=self.INBOXREPLIES)
+                            sub = r.submit(self.SUBREDDIT, title, edit.generate_pre_code(directories))
                             print "Pregame thread submitted..."
                             if self.STICKY:
                                 print "Stickying submission..."
-                                if self.FORCETOPSTICKYSLOT: sub.sticky(bottom=False)
-                                else: sub.sticky()
+                                sub.sticky()
                                 print "Submission stickied..."
-                            if self.SUGGESTED_SORT != None:
-                                print "Setting suggested sort to " + self.SUGGESTED_SORT + "..."
-                                sub.set_suggested_sort(self.SUGGESTED_SORT)
-                                print "Suggested sort set..."
                             print "Sleeping for two minutes..."
                             print datetime.strftime(datetime.today(), "%d %I:%M %p")
                             time.sleep(5)
@@ -248,13 +231,12 @@ class Bot:
                                     sub.unsticky()
 
                                 print "Submitting game thread..."
-                                sub = r.submit(self.SUBREDDIT, title, edit.generate_code(d,"game",self.TEAM_CODE), send_replies=self.INBOXREPLIES)
+                                sub = r.submit(self.SUBREDDIT, title, edit.generate_code(d,"game"))
                                 print "Game thread submitted..."
 
                                 if self.STICKY:
                                     print "Stickying submission..."
-                                    if self.FORCETOPSTICKYSLOT: sub.sticky(bottom=False)
-                                    else: sub.sticky()
+                                    sub.sticky()
                                     print "Submission stickied..."
 
                                 if self.SUGGESTED_SORT != None:
@@ -279,13 +261,14 @@ class Bot:
 
                     while True:
                         check = datetime.today()
-                        str = edit.generate_code(d,"game",self.TEAM_CODE)
+                        str = edit.generate_code(d,"game")
                         while True:
                             try:
                                 sub.edit(str)
                                 print "Edits submitted..."
                                 print "Sleeping for two minutes..."
                                 print datetime.strftime(check, "%d %I:%M %p")
+                                time.sleep(120)
                                 break
                             except Exception, err:
                                 print "Couldn't submit edits, trying again..."
@@ -328,21 +311,15 @@ class Bot:
 
                             if self.POST_GAME_THREAD:
                                 print "Submitting postgame thread..."
-                                posttitle = edit.generate_title(d,"post",self.WINLOSS_POST_THREAD_TAGS,self.TEAM_CODE)
-                                sub = r.submit(self.SUBREDDIT, posttitle, edit.generate_code(d,"post",self.TEAM_CODE), send_replies=self.INBOXREPLIES)
+                                posttitle = edit.generate_title(d,"post")
+                                sub = r.submit(self.SUBREDDIT, posttitle, edit.generate_code(d,"post"))
                                 print "Postgame thread submitted..."
 
                                 if self.STICKY:
                                     print "Stickying submission..."
-                                    if self.FORCETOPSTICKYSLOT: sub.sticky(bottom=False)
-                                    else: sub.sticky()
+                                    sub.sticky()
                                     print "Submission stickied..."
-                                if self.SUGGESTED_SORT != None:
-                                    print "Setting suggested sort to " + self.SUGGESTED_SORT + "..."
-                                    sub.set_suggested_sort(self.SUGGESTED_SORT)
-                                    print "Suggested sort set..."
                             break
-                        else: time.sleep(120)
                         time.sleep(10)
             if datetime.today().day == today.day:
                 timechecker.endofdaycheck()

--- a/src/main.py
+++ b/src/main.py
@@ -235,7 +235,7 @@ class Bot:
                                     sub.unsticky()
 
                                 print "Submitting game thread..."
-                                sub = r.submit(self.SUBREDDIT, title, edit.generate_code(d,"game",self.THEATER_LINK))
+                                sub = r.submit(self.SUBREDDIT, title, edit.generate_code(d,"game",self.TEAM_CODE,self.THEATER_LINK))
                                 print "Game thread submitted..."
 
                                 if self.STICKY:
@@ -265,7 +265,7 @@ class Bot:
 
                     while True:
                         check = datetime.today()
-                        str = edit.generate_code(d,"game",self.THEATER_LINK)
+                        str = edit.generate_code(d,"game",self.TEAM_CODE,self.THEATER_LINK)
                         while True:
                             try:
                                 sub.edit(str)
@@ -316,7 +316,7 @@ class Bot:
                             if self.POST_GAME_THREAD:
                                 print "Submitting postgame thread..."
                                 posttitle = edit.generate_title(d,"post")
-                                sub = r.submit(self.SUBREDDIT, posttitle, edit.generate_code(d,"post",self.THEATER_LINK))
+                                sub = r.submit(self.SUBREDDIT, posttitle, edit.generate_code(d,"post",self.TEAM_CODE,self.THEATER_LINK))
                                 print "Postgame thread submitted..."
 
                                 if self.STICKY:

--- a/src/main.py
+++ b/src/main.py
@@ -231,7 +231,7 @@ class Bot:
                                     sub.unsticky()
 
                                 print "Submitting game thread..."
-                                sub = r.submit(self.SUBREDDIT, title, edit.generate_code(d,"game",self.TEAM_CODE))
+                                sub = r.submit(self.SUBREDDIT, title, edit.generate_code(d,"game"))
                                 print "Game thread submitted..."
 
                                 if self.STICKY:
@@ -261,7 +261,7 @@ class Bot:
 
                     while True:
                         check = datetime.today()
-                        str = edit.generate_code(d,"game",self.TEAM_CODE)
+                        str = edit.generate_code(d,"game")
                         while True:
                             try:
                                 sub.edit(str)
@@ -312,7 +312,7 @@ class Bot:
                             if self.POST_GAME_THREAD:
                                 print "Submitting postgame thread..."
                                 posttitle = edit.generate_title(d,"post")
-                                sub = r.submit(self.SUBREDDIT, posttitle, edit.generate_code(d,"post",self.TEAM_CODE))
+                                sub = r.submit(self.SUBREDDIT, posttitle, edit.generate_code(d,"post"))
                                 print "Postgame thread submitted..."
 
                                 if self.STICKY:

--- a/src/main.py
+++ b/src/main.py
@@ -31,6 +31,7 @@ class Bot:
         self.PREGAME_THREAD = None
         self.POST_GAME_THREAD = None
         self.STICKY = None
+        self.FORCETOPSTICKYSLOT = None
         self.SUGGESTED_SORT = None
         self.MESSAGE = None
         self.PRE_THREAD_SETTINGS = None
@@ -76,6 +77,11 @@ class Bot:
 
             self.STICKY = settings.get('STICKY')
             if self.STICKY == None: return "Missing STICKY"
+            
+            self.FORCETOPSTICKYSLOT = settings.get('FORCETOPSTICKYSLOT')
+            if self.FORCETOPSTICKYSLOT == None: return "Missing FORCETOPSTICKYSLOT"
+            if self.FORCETOPSTICKYSLOT: self.BOTTOMSTICKY = "bottom=False"
+            else: self.BOTTOMSTICKY = ""
 
             self.SUGGESTED_SORT = settings.get('SUGGESTED_SORT')
             if self.SUGGESTED_SORT == None: return "Missing SUGGESTED_SORT"
@@ -195,7 +201,7 @@ class Bot:
                             print "Pregame thread submitted..."
                             if self.STICKY:
                                 print "Stickying submission..."
-                                sub.sticky(bottom=False)
+                                sub.sticky(self.BOTTOMSTICKY)
                                 print "Submission stickied..."
                             print "Sleeping for two minutes..."
                             print datetime.strftime(datetime.today(), "%d %I:%M %p")
@@ -226,7 +232,7 @@ class Bot:
                                 print "Game thread submitted..."
                                 if self.STICKY:
                                     print "Stickying submission..."
-                                    sub.sticky(bottom=False)
+                                    sub.sticky(self.BOTTOMSTICKY)
                                     print "Submission stickied..."
                                 if self.SUGGESTED_SORT != None:
                                     print "Setting suggested sort to " + self.SUGGESTED_SORT + "..."
@@ -297,7 +303,7 @@ class Bot:
                                 print "Postgame thread submitted..."
                                 if self.STICKY:
                                     print "Stickying submission..."
-                                    sub.sticky(bottom=False)
+                                    sub.sticky(self.BOTTOMSTICKY)
                                     print "Submission stickied..."
                             break
                         time.sleep(10)

--- a/src/main.py
+++ b/src/main.py
@@ -80,8 +80,6 @@ class Bot:
             
             self.FORCETOPSTICKYSLOT = settings.get('FORCETOPSTICKYSLOT')
             if self.FORCETOPSTICKYSLOT == None: return "Missing FORCETOPSTICKYSLOT"
-            if self.FORCETOPSTICKYSLOT: self.BOTTOMSTICKY = "bottom=False"
-            else: self.BOTTOMSTICKY = ""
 
             self.SUGGESTED_SORT = settings.get('SUGGESTED_SORT')
             if self.SUGGESTED_SORT == None: return "Missing SUGGESTED_SORT"
@@ -201,7 +199,8 @@ class Bot:
                             print "Pregame thread submitted..."
                             if self.STICKY:
                                 print "Stickying submission..."
-                                sub.sticky(self.BOTTOMSTICKY)
+                                if self.FORCETOPSTICKYSLOT: sub.sticky(bottom=False)
+                                else: sub.sticky()
                                 print "Submission stickied..."
                             print "Sleeping for two minutes..."
                             print datetime.strftime(datetime.today(), "%d %I:%M %p")
@@ -232,7 +231,8 @@ class Bot:
                                 print "Game thread submitted..."
                                 if self.STICKY:
                                     print "Stickying submission..."
-                                    sub.sticky(self.BOTTOMSTICKY)
+                                    if self.FORCETOPSTICKYSLOT: sub.sticky(bottom=False)
+                                    else: sub.sticky()
                                     print "Submission stickied..."
                                 if self.SUGGESTED_SORT != None:
                                     print "Setting suggested sort to " + self.SUGGESTED_SORT + "..."
@@ -303,7 +303,8 @@ class Bot:
                                 print "Postgame thread submitted..."
                                 if self.STICKY:
                                     print "Stickying submission..."
-                                    sub.sticky(self.BOTTOMSTICKY)
+                                    if self.FORCETOPSTICKYSLOT: sub.sticky(bottom=False)
+                                    else: sub.sticky()
                                     print "Submission stickied..."
                             break
                         time.sleep(10)

--- a/src/main.py
+++ b/src/main.py
@@ -253,7 +253,6 @@ class Bot:
                                 print "Edits submitted..."
                                 print "Sleeping for two minutes..."
                                 print datetime.strftime(check, "%d %I:%M %p")
-                                time.sleep(120)
                                 break
                             except Exception, err:
                                 print "Couldn't submit edits, trying again..."
@@ -300,6 +299,7 @@ class Bot:
                                     sub.sticky()
                                     print "Submission stickied..."
                             break
+                        else: time.sleep(120)
                         time.sleep(10)
             if datetime.today().day == today.day:
                 timechecker.endofdaycheck()

--- a/src/main.py
+++ b/src/main.py
@@ -35,7 +35,6 @@ class Bot:
         self.STICKY = None
         self.SUGGESTED_SORT = None
         self.MESSAGE = None
-        self.THEATER_LINK = None
         self.PRE_THREAD_SETTINGS = None
         self.THREAD_SETTINGS = None
         self.POST_THREAD_SETTINGS = None
@@ -103,7 +102,7 @@ class Bot:
             self.THREAD_SETTINGS = (temp_settings.get('THREAD_TAG'),
                                     (content_settings.get('HEADER'), content_settings.get('BOX_SCORE'),
                                      content_settings.get('LINE_SCORE'), content_settings.get('SCORING_PLAYS'),
-                                     content_settings.get('HIGHLIGHTS'), content_settings.get('FOOTER'))
+                                     content_settings.get('HIGHLIGHTS'), content_settings.get('FOOTER'), content_settings.get('THEATER_LINK'))
                                  )
             if self.THREAD_SETTINGS == None: return "Missing THREAD_SETTINGS"
 
@@ -112,7 +111,7 @@ class Bot:
             self.POST_THREAD_SETTINGS = (temp_settings.get('POST_THREAD_TAG'),
                                     (content_settings.get('HEADER'), content_settings.get('BOX_SCORE'),
                                      content_settings.get('LINE_SCORE'), content_settings.get('SCORING_PLAYS'),
-                                     content_settings.get('HIGHLIGHTS'), content_settings.get('FOOTER'))
+                                     content_settings.get('HIGHLIGHTS'), content_settings.get('FOOTER'), content_settings.get('THEATER_LINK'))
                                  )
             if self.POST_THREAD_SETTINGS == None: return "Missing POST_THREAD_SETTINGS"
 
@@ -235,7 +234,7 @@ class Bot:
                                     sub.unsticky()
 
                                 print "Submitting game thread..."
-                                sub = r.submit(self.SUBREDDIT, title, edit.generate_code(d,"game",self.TEAM_CODE,self.THEATER_LINK))
+                                sub = r.submit(self.SUBREDDIT, title, edit.generate_code(d,"game",self.TEAM_CODE))
                                 print "Game thread submitted..."
 
                                 if self.STICKY:
@@ -265,7 +264,7 @@ class Bot:
 
                     while True:
                         check = datetime.today()
-                        str = edit.generate_code(d,"game",self.TEAM_CODE,self.THEATER_LINK)
+                        str = edit.generate_code(d,"game",self.TEAM_CODE)
                         while True:
                             try:
                                 sub.edit(str)
@@ -316,7 +315,7 @@ class Bot:
                             if self.POST_GAME_THREAD:
                                 print "Submitting postgame thread..."
                                 posttitle = edit.generate_title(d,"post")
-                                sub = r.submit(self.SUBREDDIT, posttitle, edit.generate_code(d,"post",self.TEAM_CODE,self.THEATER_LINK))
+                                sub = r.submit(self.SUBREDDIT, posttitle, edit.generate_code(d,"post",self.TEAM_CODE))
                                 print "Postgame thread submitted..."
 
                                 if self.STICKY:

--- a/src/main.py
+++ b/src/main.py
@@ -33,6 +33,7 @@ class Bot:
         self.STICKY = None
         self.SUGGESTED_SORT = None
         self.MESSAGE = None
+        self.INBOXREPLIES = None
         self.PRE_THREAD_SETTINGS = None
         self.THREAD_SETTINGS = None
         self.POST_THREAD_SETTINGS = None
@@ -82,6 +83,9 @@ class Bot:
 
             self.MESSAGE = settings.get('MESSAGE')
             if self.MESSAGE == None: return "Missing MESSAGE"
+
+            self.INBOXREPLIES = settings.get('INBOXREPLIES')
+            if self.INBOXREPLIES == None: return "Missing INBOXREPLIES"
 
             temp_settings = settings.get('PRE_THREAD_SETTINGS')
             content_settings = temp_settings.get('CONTENT')
@@ -191,7 +195,7 @@ class Bot:
                                 break
                         if not posted:
                             print "Submitting pregame thread..."
-                            sub = r.submit(self.SUBREDDIT, title, edit.generate_pre_code(directories))
+                            sub = r.submit(self.SUBREDDIT, title, edit.generate_pre_code(directories), send_replies=self.INBOXREPLIES)
                             print "Pregame thread submitted..."
                             if self.STICKY:
                                 print "Stickying submission..."
@@ -222,7 +226,7 @@ class Bot:
                                     break
                             if not posted:
                                 print "Submitting game thread..."
-                                sub = r.submit(self.SUBREDDIT, title, edit.generate_code(d,"game"))
+                                sub = r.submit(self.SUBREDDIT, title, edit.generate_code(d,"game"), send_replies=self.INBOXREPLIES)
                                 print "Game thread submitted..."
                                 if self.STICKY:
                                     print "Stickying submission..."
@@ -293,7 +297,7 @@ class Bot:
                             if self.POST_GAME_THREAD:
                                 print "Submitting postgame thread..."
                                 posttitle = edit.generate_title(d,"post")
-                                sub = r.submit(self.SUBREDDIT, posttitle, edit.generate_code(d,"post"))
+                                sub = r.submit(self.SUBREDDIT, posttitle, edit.generate_code(d,"post"), send_replies=self.INBOXREPLIES)
                                 print "Postgame thread submitted..."
                                 if self.STICKY:
                                     print "Stickying submission..."

--- a/src/main.py
+++ b/src/main.py
@@ -235,7 +235,7 @@ class Bot:
                                     sub.unsticky()
 
                                 print "Submitting game thread..."
-                                sub = r.submit(self.SUBREDDIT, title, edit.generate_code(d,"game"))
+                                sub = r.submit(self.SUBREDDIT, title, edit.generate_code(d,"game",self.THEATER_LINK))
                                 print "Game thread submitted..."
 
                                 if self.STICKY:
@@ -265,7 +265,7 @@ class Bot:
 
                     while True:
                         check = datetime.today()
-                        str = edit.generate_code(d,"game")
+                        str = edit.generate_code(d,"game",self.THEATER_LINK)
                         while True:
                             try:
                                 sub.edit(str)
@@ -316,7 +316,7 @@ class Bot:
                             if self.POST_GAME_THREAD:
                                 print "Submitting postgame thread..."
                                 posttitle = edit.generate_title(d,"post")
-                                sub = r.submit(self.SUBREDDIT, posttitle, edit.generate_code(d,"post"))
+                                sub = r.submit(self.SUBREDDIT, posttitle, edit.generate_code(d,"post",self.THEATER_LINK))
                                 print "Postgame thread submitted..."
 
                                 if self.STICKY:

--- a/src/main.py
+++ b/src/main.py
@@ -197,6 +197,10 @@ class Bot:
                                 print "Stickying submission..."
                                 sub.sticky()
                                 print "Submission stickied..."
+                            if self.SUGGESTED_SORT != None:
+                                print "Setting suggested sort to " + self.SUGGESTED_SORT + "..."
+                                sub.set_suggested_sort(self.SUGGESTED_SORT)
+                                print "Suggested sort set..."
                             print "Sleeping for two minutes..."
                             print datetime.strftime(datetime.today(), "%d %I:%M %p")
                             time.sleep(5)
@@ -299,6 +303,10 @@ class Bot:
                                     print "Stickying submission..."
                                     sub.sticky()
                                     print "Submission stickied..."
+                                if self.SUGGESTED_SORT != None:
+                                    print "Setting suggested sort to " + self.SUGGESTED_SORT + "..."
+                                    sub.set_suggested_sort(self.SUGGESTED_SORT)
+                                    print "Suggested sort set..."
                             break
                         time.sleep(10)
             if datetime.today().day == today.day:

--- a/src/main.py
+++ b/src/main.py
@@ -195,7 +195,7 @@ class Bot:
                             print "Pregame thread submitted..."
                             if self.STICKY:
                                 print "Stickying submission..."
-                                sub.sticky()
+                                sub.sticky(bottom=False)
                                 print "Submission stickied..."
                             print "Sleeping for two minutes..."
                             print datetime.strftime(datetime.today(), "%d %I:%M %p")
@@ -226,7 +226,7 @@ class Bot:
                                 print "Game thread submitted..."
                                 if self.STICKY:
                                     print "Stickying submission..."
-                                    sub.sticky()
+                                    sub.sticky(bottom=False)
                                     print "Submission stickied..."
                                 if self.SUGGESTED_SORT != None:
                                     print "Setting suggested sort to " + self.SUGGESTED_SORT + "..."
@@ -297,7 +297,7 @@ class Bot:
                                 print "Postgame thread submitted..."
                                 if self.STICKY:
                                     print "Stickying submission..."
-                                    sub.sticky()
+                                    sub.sticky(bottom=False)
                                     print "Submission stickied..."
                             break
                         time.sleep(10)


### PR DESCRIPTION
This pull request adds the ability to include a link to the game's highlights page on http://baseball.theater in the game threads and post game threads. This is helpful because any highlights added to the MLB site after the game ends are not included in the game and post game threads. 

The new setting is THEATER_LINK under the THREAD_SETTINGS and POST_THREAD_SETTINGS sections. The link will appear as the last row of the Highlights table, with the text "See all highlights at Baseball.Theater."
 with "Baseball.Theater" linking to http://baseball.theater/team/phi/game/YYYYMMDD (phi and YYYYMMDD will be replaced with the bot's team and the current date).