### PR TITLE
Add support for offday threads (PRAW5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ Version 1.0 was written in a mix of Python and Java, and has been
 
 ### Set Up OAuth
 
-Go to reddit.com’s app page, click on the “are you a developer? create an app” button. Fill out the name, description and about url. Name must be filled out, but the rest doesn’t. Write whatever you please. For redirect uri set it to `http://127.0.0.1:65010/authorize_callback`. All four variables can be changed later.
+Go to reddit.com’s app page (https://www.reddit.com/prefs/apps), click on the “are you a developer? create an app” button. Fill out the name, description and about url. Name must be filled out, but the rest doesn’t. Write whatever you please. For redirect uri set it to `http://localhost:8080`. All four variables can be changed later.
 
 Next, open setup.py, fill in the client_id, client_secret and redirect_uri fields and run the script. Your browser will open. Click allow on the displayed web page. 
 
-Enter the uniqueKey&code from the URL into the console -- wrapped in single quotes -- and the access information will be printed. This includes the final bit of info you need, the refresh token.
+Enter the code (everything after code=) from the URL in the browser address bar into the console -- wrapped in single quotes -- and the final bit of info you need will be displayed: the refresh token. Copy the refresh token for the next step.
 
 Finally, Copy sample_settings.json to the src folder and rename it to settings.json. Fill in the CLIENT_ID, CLIENT_SECRET, REDIRECT_URI and REFRESH_TOKEN fields in the settings.json file and save. 
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To use the default settings, copy `sample_settings.json` into `src/settings.json
 
 * `POST_GAME_THREAD` - do you want a post game thread?
 
-* `SUGGESTED_SORT` - what do you want the suggested sort to be? ("confidence", "top", "new", "controversial", "old", "random", "qa", "")
+* `SUGGESTED_SORT` - what do you want the suggested sort to be? set to "" if your bot user does not have mod rights ("confidence", "top", "new", "controversial", "old", "random", "qa", "")
 
 * `STICKY` - do you want the thread stickied? (mod only)
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ To use the default settings, copy `sample_settings.json` into `src/settings.json
 
 #### Descriptions of Settings
 
+* `USER_AGENT` - user agent string to identify your bot to the Reddit API
+
 * `BOT_TIME_ZONE` - time zone of the computer running the bot, uncomment the line that you want to use
 
 * `TIME_ZONE` - time zone of the team. uncomment the line that you want to use

--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ To use the default settings, copy `sample_settings.json` into `src/settings.json
 
 * `MESSAGE` - send submission shortlink to /u/baseballbot
 
-* `WINLOSS_POST_THREAD_TAGS` - do you want to use different postgame thread tags for wins and losses? (configure in POST_THREAD_SETTINGS)
-
 * `INBOXREPLIES` - do you want to receive thread replies in the bot's inbox?
 
 * `FLAIR_MODE` - do you want to set flair on pre/game/post threads as the thread submitter (sub settings must allow), using a mod command (bot user must have mod rights), or none? ("none", "submitter", "mod") NOTE: in order to use this, you may have to re-do the OAuth setup process described above to obtain a new refresh token that includes flair permissions.
+
+* `OFFDAY_THREAD_SETTINGS` - what to include in the offday threads
 
 * `PRE_THREAD_SETTINGS` - what to include in the pregame threads
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ To use the default settings, copy `sample_settings.json` into `src/settings.json
 
 * `INBOXREPLIES` - do you want to receive thread replies in the bot's inbox?
 
-* `FLAIR_MODE` - do you want to set flair on pre/game/post threads as the thread submitter (sub settings must allow), using a mod command (bot user must have mod rights), or none? ("none", "submitter", "mod")
+* `FLAIR_MODE` - do you want to set flair on pre/game/post threads as the thread submitter (sub settings must allow), using a mod command (bot user must have mod rights), or none? ("none", "submitter", "mod") NOTE: in order to use this, you may have to re-do the OAuth setup process described above to obtain a new refresh token that includes flair permissions.
 
 * `PRE_THREAD_SETTINGS` - what to include in the pregame threads
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Baseball GDT Bot by Matt Bullock
 =====================================
 
-### Current Version: 3.0.2
+### Current Version: 3.0.3
 	
 The point of this project is to create a bot that will generate a
 	game discussion thread that contains live linescore and boxscore,
@@ -76,7 +76,7 @@ Modules being used:
 
 ### Updates
 
-#### v3.0.2
+#### v3.0.3
 * Updated to support praw 5.0.1
 
 #### v3.0.2

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Modules being used:
 
 #### v3.0.3
 * Updated to support praw 5.0.1
+* Added support for offday threads
 
 #### v3.0.2
 * GUI added. 

--- a/README.md
+++ b/README.md
@@ -45,13 +45,15 @@ To use the default settings, copy `sample_settings.json` into `src/settings.json
 
 * `POST_GAME_THREAD` - do you want a post game thread?
 
-* `SUGGESTED_SORT` - what do you want the suggested sort to be? ("confidence", "top", "new", "controversial", "old", "random", "qa", "")
+* `SUGGESTED_SORT` - what do you want the suggested sort to be? set to "" if your bot user does not have mod rights ("confidence", "top", "new", "controversial", "old", "random", "qa", "")
 
 * `STICKY` - do you want the thread stickied? (mod only)
 
 * `MESSAGE` - send submission shortlink to /u/baseballbot
 
 * `INBOXREPLIES` - do you want to receive thread replies in the bot's inbox?
+
+* `FLAIR_MODE` - do you want to set flair on pre/game/post threads as the thread submitter (sub settings must allow), using a mod command (bot user must have mod rights), or none? ("none", "submitter", "mod")
 
 * `PRE_THREAD_SETTINGS` - what to include in the pregame threads
 

--- a/README.md
+++ b/README.md
@@ -69,12 +69,15 @@ This was written in Python 2.7, so beware if you are running Python 3 or
 	
 Modules being used:
 
-	praw - interfacing reddit
+	praw 5.0.1 - interfacing reddit
 	simplejson - JSON parsing
 	urllib2 - pulling data from MLB servers
 	ElementTree - XML parsing
 
 ### Updates
+
+#### v3.0.2
+* Updated to support praw 5.0.1
 
 #### v3.0.2
 * GUI added. 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ To use the default settings, copy `sample_settings.json` into `src/settings.json
 
 * `MESSAGE` - send submission shortlink to /u/baseballbot
 
+* `WINLOSS_POST_THREAD_TAGS` - do you want to use different postgame thread tags for wins and losses? (configure in POST_THREAD_SETTINGS)
+
 * `INBOXREPLIES` - do you want to receive thread replies in the bot's inbox?
 
 * `PRE_THREAD_SETTINGS` - what to include in the pregame threads

--- a/sample_settings.json
+++ b/sample_settings.json
@@ -9,6 +9,7 @@
     "POST_TIME": 1,
     "SUBREDDIT": "XXX",
     "TEAM_CODE": "XXX",
+    "OFFDAY_THREAD": false,
     "PREGAME_THREAD": false,
     "POST_GAME_THREAD": false,
     "STICKY": true,
@@ -16,6 +17,12 @@
     "MESSAGE": false,
     "INBOXREPLIES": false,
     "FLAIR_MODE": "none",
+    "OFFDAY_THREAD_SETTINGS": {
+        "OFFDAY_THREAD_TAG": "OFFDAY THREAD:",
+        "OFFDAY_THREAD_TIME": "9AM",
+        "OFFDAY_THREAD_BODY": "who wants cookies?",
+        "OFFDAY_THREAD_FLAIR": ""
+    },
     "WINLOSS_POST_THREAD_TAGS": false,
     "PRE_THREAD_SETTINGS": {
         "PRE_THREAD_TAG": "PREGAME THREAD:",

--- a/sample_settings.json
+++ b/sample_settings.json
@@ -14,6 +14,7 @@
     "SUGGESTED_SORT": "new",
     "MESSAGE": false,
     "INBOXREPLIES": false,
+    "WINLOSS_POST_THREAD_TAGS": false,
     "PRE_THREAD_SETTINGS": {
         "PRE_THREAD_TAG": "PREGAME THREAD:",
         "PRE_THREAD_TIME": "9AM",
@@ -35,6 +36,8 @@
     },
     "POST_THREAD_SETTINGS": {
         "POST_THREAD_TAG": "POST GAME THREAD:",
+        "POST_THREAD_WIN_TAG": "OUR TEAM WON:",
+        "POST_THREAD_LOSS_TAG": "OUR TEAM LOST:",
         "CONTENT": {
             "HEADER": true,
             "BOX_SCORE": true,

--- a/sample_settings.json
+++ b/sample_settings.json
@@ -9,12 +9,20 @@
     "POST_TIME": 1,
     "SUBREDDIT": "XXX",
     "TEAM_CODE": "XXX",
+    "OFFDAY_THREAD": false,
     "PREGAME_THREAD": false,
     "POST_GAME_THREAD": false,
     "STICKY": true,
     "SUGGESTED_SORT": "new",
     "MESSAGE": false,
     "INBOXREPLIES": false,
+    "FLAIR_MODE": "none",
+    "OFFDAY_THREAD_SETTINGS": {
+        "OFFDAY_THREAD_TAG": "OFFDAY THREAD:",
+        "OFFDAY_THREAD_TIME": "9AM",
+        "OFFDAY_THREAD_BODY": "who wants cookies?",
+        "OFFDAY_THREAD_FLAIR": ""
+    },
     "PRE_THREAD_SETTINGS": {
         "PRE_THREAD_TAG": "PREGAME THREAD:",
         "PRE_THREAD_TIME": "9AM",

--- a/sample_settings.json
+++ b/sample_settings.json
@@ -15,9 +15,11 @@
     "SUGGESTED_SORT": "new",
     "MESSAGE": false,
     "INBOXREPLIES": false,
+    "FLAIR_MODE": "none",
     "PRE_THREAD_SETTINGS": {
         "PRE_THREAD_TAG": "PREGAME THREAD:",
         "PRE_THREAD_TIME": "9AM",
+        "FLAIR": "",
         "CONTENT": {
             "PROBABLES": true,
             "FIRST_PITCH": true
@@ -25,6 +27,7 @@
     },
     "THREAD_SETTINGS": {
         "THREAD_TAG": "GAME THREAD:",
+        "FLAIR": "",
         "CONTENT": {
             "HEADER": true,
             "BOX_SCORE": true,
@@ -36,6 +39,7 @@
     },
     "POST_THREAD_SETTINGS": {
         "POST_THREAD_TAG": "POST GAME THREAD:",
+        "FLAIR": "",
         "CONTENT": {
             "HEADER": true,
             "BOX_SCORE": true,

--- a/sample_settings.json
+++ b/sample_settings.json
@@ -2,7 +2,7 @@
     "CLIENT_ID": "XXX",
     "CLIENT_SECRET": "XXX",
     "USER_AGENT": "OAuth Baseball-GDT-Bot V. 3.0.3 https://github.com/mattabullock/Baseball-GDT-Bot",
-    "REDIRECT_URI": "http://127.0.0.1:65010/authorize_callback",
+    "REDIRECT_URI": "http://localhost:8080",
     "REFRESH_TOKEN": "XXX",
     "BOT_TIME_ZONE": "ET",
     "TEAM_TIME_ZONE": "ET",

--- a/sample_settings.json
+++ b/sample_settings.json
@@ -26,7 +26,6 @@
     "PRE_THREAD_SETTINGS": {
         "PRE_THREAD_TAG": "PREGAME THREAD:",
         "PRE_THREAD_TIME": "9AM",
-        "FLAIR": "",
         "CONTENT": {
             "PROBABLES": true,
             "FIRST_PITCH": true
@@ -34,30 +33,24 @@
     },
     "THREAD_SETTINGS": {
         "THREAD_TAG": "GAME THREAD:",
-        "FLAIR": "",
         "CONTENT": {
             "HEADER": true,
             "BOX_SCORE": true,
             "LINE_SCORE": true,
             "SCORING_PLAYS": true,
             "HIGHLIGHTS": true,
-            "FOOTER": "",
-            "THEATER_LINK": false
+            "FOOTER": ""
         }
     },
     "POST_THREAD_SETTINGS": {
         "POST_THREAD_TAG": "POST GAME THREAD:",
-        "FLAIR": "",
-        "POST_THREAD_WIN_TAG": "OUR TEAM WON:",
-        "POST_THREAD_LOSS_TAG": "OUR TEAM LOST:",
         "CONTENT": {
             "HEADER": true,
             "BOX_SCORE": true,
             "LINE_SCORE": true,
             "SCORING_PLAYS": true,
             "HIGHLIGHTS": true,
-            "FOOTER": "",
-            "THEATER_LINK": false
+            "FOOTER": ""
         }
     }
 }

--- a/sample_settings.json
+++ b/sample_settings.json
@@ -16,7 +16,6 @@
     "SUGGESTED_SORT": "new",
     "MESSAGE": false,
     "INBOXREPLIES": false,
-    "WINLOSS_POST_THREAD_TAGS": false,
     "FLAIR_MODE": "none",
     "OFFDAY_THREAD_SETTINGS": {
         "OFFDAY_THREAD_TAG": "OFFDAY THREAD:",

--- a/sample_settings.json
+++ b/sample_settings.json
@@ -1,6 +1,7 @@
 {
     "CLIENT_ID": "XXX",
     "CLIENT_SECRET": "XXX",
+    "USER_AGENT": "OAuth Baseball-GDT-Bot V. 3.0.3 https://github.com/mattabullock/Baseball-GDT-Bot",
     "REDIRECT_URI": "http://127.0.0.1:65010/authorize_callback",
     "REFRESH_TOKEN": "XXX",
     "BOT_TIME_ZONE": "ET",

--- a/sample_settings.json
+++ b/sample_settings.json
@@ -30,7 +30,8 @@
             "LINE_SCORE": true,
             "SCORING_PLAYS": true,
             "HIGHLIGHTS": true,
-            "FOOTER": ""
+            "FOOTER": "",
+            "THEATER_LINK": false
         }
     },
     "POST_THREAD_SETTINGS": {
@@ -41,7 +42,8 @@
             "LINE_SCORE": true,
             "SCORING_PLAYS": true,
             "HIGHLIGHTS": true,
-            "FOOTER": ""
+            "FOOTER": "",
+            "THEATER_LINK": false
         }
     }
 }

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,10 @@
 import praw
-r = praw.Reddit(client_id='XXX',
-                client_secret='XXX',
+r = praw.Reddit(client_id='xxx',
+                client_secret='xxx',
                 redirect_uri='http://localhost:8080',
                 user_agent='OAuth Baseball-GDT Ver. 3.0.3 Setup')
 
-url = r.auth.url(['identity', 'submit', 'edit', 'read', 'modposts', 'privatemessages'], '...', 'permanent')
+url = r.auth.url(['identity', 'submit', 'edit', 'read', 'modposts', 'privatemessages', 'flair', 'modflair'], '...', 'permanent')
 import webbrowser
 webbrowser.open(url)
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import praw
-r = praw.Reddit(client_id='Y9ii85xkpxdFdw',
-                client_secret='APUT0YMWILRisrdSk4YTNs41c10',
+r = praw.Reddit(client_id='XXX',
+                client_secret='XXX',
                 redirect_uri='http://localhost:8080',
                 user_agent='OAuth Baseball-GDT Ver. 3.0.3 Setup')
 

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,14 @@
 import praw
-r = praw.Reddit('OAuth Baseball-GDT Ver. 3.0.0 Setup')
-r.set_oauth_app_info(client_id='xxx',
-                    client_secret='xxx',
-                    redirect_uri='http://127.0.0.1:65010/authorize_callback')
-								   
-url = r.get_authorize_url('uniqueKey', 'submit edit read modposts privatemessages', True)
+r = praw.Reddit(client_id='Y9ii85xkpxdFdw',
+                client_secret='APUT0YMWILRisrdSk4YTNs41c10',
+                redirect_uri='http://localhost:8080',
+                user_agent='OAuth Baseball-GDT Ver. 3.0.3 Setup')
+
+url = r.auth.url(['identity', 'submit', 'edit', 'read', 'modposts', 'privatemessages'], '...', 'permanent')
 import webbrowser
 webbrowser.open(url)
 
-var_input = input("Enter uniqueKey&code: ")
-access_information = r.get_access_information(var_input)
+var_input = input("Enter code: ")
+access_information = r.auth.authorize(var_input)
 print access_information
 raw_input()

--- a/src/editor.py
+++ b/src/editor.py
@@ -13,15 +13,15 @@ class Editor:
     def __init__(self,time_info,pre_thread_settings,thread_settings,
             post_thread_settings):
         (self.time_zone,self.time_change,) = time_info
-        (self.pre_thread_tag, self.pre_thread_time,
+        (self.pre_thread_tag, self.pre_thread_time, self.pre_thread_flair,
             (self.pre_probables, self.pre_first_pitch)
         ) = pre_thread_settings
-        (self.thread_tag, 
+        (self.thread_tag, self.thread_flair, 
             (self.header, self.box_score, 
              self.line_score, self.scoring_plays,
              self.highlights, self.footer)
         ) = thread_settings
-        (self.post_thread_tag, 
+        (self.post_thread_tag, self.post_thread_flair, 
             (self.post_header, self.post_box_score, 
              self.post_line_score, self.post_scoring_plays,
              self.post_highlights, self.post_footer)

--- a/src/editor.py
+++ b/src/editor.py
@@ -13,35 +13,25 @@ class Editor:
     def __init__(self,time_info,pre_thread_settings,thread_settings,
             post_thread_settings):
         (self.time_zone,self.time_change,) = time_info
-        (self.pre_thread_tag, self.pre_thread_time, self.pre_thread_flair,
+        (self.pre_thread_tag, self.pre_thread_time,
             (self.pre_probables, self.pre_first_pitch)
         ) = pre_thread_settings
-        (self.thread_tag, self.thread_flair, 
+        (self.thread_tag, 
             (self.header, self.box_score, 
              self.line_score, self.scoring_plays,
-             self.highlights, self.footer, self.theater_link)
+             self.highlights, self.footer)
         ) = thread_settings
-        (self.post_thread_tag, self.post_thread_flair, self.post_thread_win_tag, self.post_thread_loss_tag, 
+        (self.post_thread_tag, 
             (self.post_header, self.post_box_score, 
              self.post_line_score, self.post_scoring_plays,
-             self.post_highlights, self.post_footer, self.post_theater_link)
+             self.post_highlights, self.post_footer)
         ) = post_thread_settings
 
 
-    def generate_title(self,dir,thread,includewinloss=False,myteam=""):
+    def generate_title(self,dir,thread):
         if thread == "pre": title = self.pre_thread_tag + " "
         elif thread == "game": title = self.thread_tag + " "
-        elif thread == "post":
-            if includewinloss:
-                myteamwon = ""
-                myteamwon = self.didmyteamwin(dir, myteam)
-                if myteamwon == "0":
-                    title = self.post_thread_loss_tag + " "
-                elif myteamwon == "1":
-                    title = self.post_thread_win_tag + " "
-                else:
-                    title = self.post_thread_tag + " "
-            else: title = self.post_thread_tag + " "
+        elif thread == "post": title = self.post_thread_tag + " "
         while True:
             try:
                 response = urllib2.urlopen(dir + "linescore.json")
@@ -159,14 +149,14 @@ class Editor:
             if self.box_score: code = code + self.generate_boxscore(files)
             if self.line_score: code = code + self.generate_linescore(files)
             if self.scoring_plays: code = code + self.generate_scoring_plays(files)
-            if self.highlights: code = code + self.generate_highlights(files,self.theater_link)
+            if self.highlights: code = code + self.generate_highlights(files)
             if self.footer: code = code + self.footer + "\n\n"
         elif thread == "post":
             if self.post_header: code = code + self.generate_header(files)
             if self.post_box_score: code = code + self.generate_boxscore(files)
             if self.post_line_score: code = code + self.generate_linescore(files)
             if self.post_scoring_plays: code = code + self.generate_scoring_plays(files)
-            if self.post_highlights: code = code + self.generate_highlights(files,self.post_theater_link)
+            if self.post_highlights: code = code + self.generate_highlights(files)
             if self.post_footer: code = code + self.post_footer + "\n\n"
         code = code + self.generate_status(files)
         print "Returning all code..."
@@ -428,7 +418,7 @@ class Editor:
             return scoringplays
 
 
-    def generate_highlights(self,files,theater_link=False):
+    def generate_highlights(self,files):
         highlight = ""
         try:
             root = files["highlights"].getroot()
@@ -442,10 +432,6 @@ class Editor:
                         highlight = highlight + "|" + team[0] + "|[" + v.find("headline").text + "](" + v.find("url").text + ")|\n"                   
                     except:
                         highlight = highlight + "|[](/MLB)|[" + v.find("headline").text + "](" + v.find("url").text + ")|\n"                     
-            if theater_link:
-                game = files["linescore"].get('data').get('game')
-                notes = self.get_notes(game.get('home_team_name'), game.get('away_team_name'))
-                highlight = highlight + "||See all highlights at [Baseball.Theater](http://baseball.theater/team/" + notes[0] + "/game/" + datetime.now().strftime('%Y%m%d') + ")|\n"
             highlight = highlight + "\n\n"
             print "Returning highlight..."
             return highlight
@@ -555,57 +541,6 @@ class Editor:
         except:
             print "Missing data for status, returning blank text..."
             return status
-
-    def didmyteamwin(self, dir, myteam):
-    #returns 0 for loss, 1 for win, 2 for tie, 3 for postponed/suspended/canceled, blank for exception
-        myteamwon = ""
-        myteamis = ""
-        dirs = []
-        dirs.append(dir + "linescore.json")
-        dirs.append(dir + "boxscore.json")
-        dirs.append(dir + "gamecenter.xml")
-        dirs.append(dir + "plays.json")
-        dirs.append(dir + "/inning/inning_Scores.xml")
-        dirs.append(dir + "/media/mobile.xml")
-        files = self.download_files(dirs)
-        game = files["linescore"].get('data').get('game')
-
-        if game.get('home_code') == myteam:
-            myteamis = "home"
-        elif game.get('away_code') == myteam:
-            myteamis = "away"
-        else:
-            print "Cannot determine if my team is home or away, returning blank text for whether my team won..."
-            return myteamwon
-        if game.get('status') == "Game Over" or game.get('status') == "Final" or game.get('status') == "Completed Early":
-            s = files["linescore"].get('data').get('game')
-            hometeamruns = int(s.get("home_team_runs"))
-            awayteamruns = int(s.get("away_team_runs"))
-            if int(hometeamruns == awayteamruns):
-                myteamwon = "2"
-                print "Returning whether my team won (TIE)..."
-                return myteamwon
-            else:
-                if hometeamruns < awayteamruns:
-                    if myteamis == "home":
-                        myteamwon = "0"
-                    elif myteamis == "away":
-                        myteamwon = "1"
-                    print "Returning whether my team won..."
-                    return myteamwon
-                elif hometeamruns > awayteamruns:
-                    if myteamis == "home":
-                        myteamwon = "1"
-                    elif myteamis == "away":
-                        myteamwon = "0"
-                    print "Returning whether my team won..."
-                    return myteamwon
-        elif game.get('status') == "Postponed" or game.get('status') == "Suspended" or game.get('status') == "Cancelled":
-            myteamwon = "3"
-            print "Returning whether my team won (postponed, suspended, or canceled)..."
-            return myteamwon
-        print "Returning whether my team won (exception)..." + myteamwon
-        return myteamwon
 
     def get_subreddits(self, homename, awayname):
         subreddits = []

--- a/src/editor.py
+++ b/src/editor.py
@@ -21,17 +21,27 @@ class Editor:
              self.line_score, self.scoring_plays,
              self.highlights, self.footer)
         ) = thread_settings
-        (self.post_thread_tag, 
+        (self.post_thread_tag, self.post_thread_win_tag, self.post_thread_loss_tag, 
             (self.post_header, self.post_box_score, 
              self.post_line_score, self.post_scoring_plays,
              self.post_highlights, self.post_footer)
         ) = post_thread_settings
 
 
-    def generate_title(self,dir,thread):
+    def generate_title(self,dir,thread,includewinloss=False,myteam=""):
         if thread == "pre": title = self.pre_thread_tag + " "
         elif thread == "game": title = self.thread_tag + " "
-        elif thread == "post": title = self.post_thread_tag + " "
+        elif thread == "post":
+            if includewinloss:
+                myteamwon = ""
+                myteamwon = self.didmyteamwin(dir, myteam)
+                if myteamwon == "0":
+                    title = self.post_thread_loss_tag + " "
+                elif myteamwon == "1":
+                    title = self.post_thread_win_tag + " "
+                else:
+                    title = self.post_thread_tag + " "
+            else: title = self.post_thread_tag + " "
         while True:
             try:
                 response = urllib2.urlopen(dir + "linescore.json")
@@ -541,6 +551,57 @@ class Editor:
         except:
             print "Missing data for status, returning blank text..."
             return status
+
+    def didmyteamwin(self, dir, myteam):
+    #returns 0 for loss, 1 for win, 2 for tie, 3 for postponed/suspended/canceled, blank for exception
+        myteamwon = ""
+        myteamis = ""
+        dirs = []
+        dirs.append(dir + "linescore.json")
+        dirs.append(dir + "boxscore.json")
+        dirs.append(dir + "gamecenter.xml")
+        dirs.append(dir + "plays.json")
+        dirs.append(dir + "/inning/inning_Scores.xml")
+        dirs.append(dir + "/media/mobile.xml")
+        files = self.download_files(dirs)
+        game = files["linescore"].get('data').get('game')
+
+        if game.get('home_code') == myteam:
+            myteamis = "home"
+        elif game.get('away_code') == myteam:
+            myteamis = "away"
+        else:
+            print "Cannot determine if my team is home or away, returning blank text for whether my team won..."
+            return myteamwon
+        if game.get('status') == "Game Over" or game.get('status') == "Final" or game.get('status') == "Completed Early":
+            s = files["linescore"].get('data').get('game')
+            hometeamruns = int(s.get("home_team_runs"))
+            awayteamruns = int(s.get("away_team_runs"))
+            if int(hometeamruns == awayteamruns):
+                myteamwon = "2"
+                print "Returning whether my team won (TIE)..."
+                return myteamwon
+            else:
+                if hometeamruns < awayteamruns:
+                    if myteamis == "home":
+                        myteamwon = "0"
+                    elif myteamis == "away":
+                        myteamwon = "1"
+                    print "Returning whether my team won..."
+                    return myteamwon
+                elif hometeamruns > awayteamruns:
+                    if myteamis == "home":
+                        myteamwon = "1"
+                    elif myteamis == "away":
+                        myteamwon = "0"
+                    print "Returning whether my team won..."
+                    return myteamwon
+        elif game.get('status') == "Postponed" or game.get('status') == "Suspended" or game.get('status') == "Cancelled":
+            myteamwon = "3"
+            print "Returning whether my team won (postponed, suspended, or canceled)..."
+            return myteamwon
+        print "Returning whether my team won (exception)..." + myteamwon
+        return myteamwon
 
     def get_subreddits(self, homename, awayname):
         subreddits = []

--- a/src/editor.py
+++ b/src/editor.py
@@ -19,12 +19,12 @@ class Editor:
         (self.thread_tag, 
             (self.header, self.box_score, 
              self.line_score, self.scoring_plays,
-             self.highlights, self.footer)
+             self.highlights, self.footer, self.theater_link)
         ) = thread_settings
         (self.post_thread_tag, 
             (self.post_header, self.post_box_score, 
              self.post_line_score, self.post_scoring_plays,
-             self.post_highlights, self.post_footer)
+             self.post_highlights, self.post_footer, self.post_theater_link)
         ) = post_thread_settings
 
 
@@ -149,14 +149,14 @@ class Editor:
             if self.box_score: code = code + self.generate_boxscore(files)
             if self.line_score: code = code + self.generate_linescore(files)
             if self.scoring_plays: code = code + self.generate_scoring_plays(files)
-            if self.highlights: code = code + self.generate_highlights(files)
+            if self.highlights: code = code + self.generate_highlights(files,self.theater_link)
             if self.footer: code = code + self.footer + "\n\n"
         elif thread == "post":
             if self.post_header: code = code + self.generate_header(files)
             if self.post_box_score: code = code + self.generate_boxscore(files)
             if self.post_line_score: code = code + self.generate_linescore(files)
             if self.post_scoring_plays: code = code + self.generate_scoring_plays(files)
-            if self.post_highlights: code = code + self.generate_highlights(files)
+            if self.post_highlights: code = code + self.generate_highlights(files,self.post_theater_link)
             if self.post_footer: code = code + self.post_footer + "\n\n"
         code = code + self.generate_status(files)
         print "Returning all code..."
@@ -418,7 +418,7 @@ class Editor:
             return scoringplays
 
 
-    def generate_highlights(self,files):
+    def generate_highlights(self,files,theater_link=False):
         highlight = ""
         try:
             root = files["highlights"].getroot()
@@ -432,6 +432,10 @@ class Editor:
                         highlight = highlight + "|" + team[0] + "|[" + v.find("headline").text + "](" + v.find("url").text + ")|\n"                   
                     except:
                         highlight = highlight + "|[](/MLB)|[" + v.find("headline").text + "](" + v.find("url").text + ")|\n"                     
+            if theater_link:
+                game = files["linescore"].get('data').get('game')
+                notes = self.get_notes(game.get('home_team_name'), game.get('away_team_name'))
+                highlight = highlight + "||See all highlights at [Baseball.Theater](http://baseball.theater/team/" + notes[0] + "/game/" + datetime.now().strftime('%Y%m%d') + ")|\n"
             highlight = highlight + "\n\n"
             print "Returning highlight..."
             return highlight

--- a/src/main.py
+++ b/src/main.py
@@ -323,7 +323,7 @@ class Bot:
 
                                 if self.MESSAGE:
                                     print "Messaging Baseballbot..."
-                                    r.send_message('baseballbot', 'Gamethread posted', sub.short_link)
+                                    r.redditor('baseballbot').message('Gamethread posted', sub.shortlink)
                                     print "Baseballbot messaged..."
 
                             print "Sleeping for two minutes..."

--- a/src/main.py
+++ b/src/main.py
@@ -35,7 +35,6 @@ class Bot:
         self.STICKY = None
         self.SUGGESTED_SORT = None
         self.MESSAGE = None
-        self.WINLOSS_POST_THREAD_TAGS = None
         self.INBOXREPLIES = None
         self.FLAIR_MODE = None
         self.PRE_THREAD_SETTINGS = None
@@ -116,31 +115,28 @@ class Bot:
 
             temp_settings = settings.get('PRE_THREAD_SETTINGS')
             content_settings = temp_settings.get('CONTENT')
-            self.PRE_THREAD_SETTINGS = (temp_settings.get('PRE_THREAD_TAG'),temp_settings.get('PRE_THREAD_TIME'),temp_settings.get('FLAIR'),
+            self.PRE_THREAD_SETTINGS = (temp_settings.get('PRE_THREAD_TAG'),temp_settings.get('PRE_THREAD_TIME'),
                                             (content_settings.get('PROBABLES'),content_settings.get('FIRST_PITCH'))
                                        )
             if self.PRE_THREAD_SETTINGS == None: return "Missing PRE_THREAD_SETTINGS"
 
             temp_settings = settings.get('THREAD_SETTINGS')
             content_settings = temp_settings.get('CONTENT')
-            self.THREAD_SETTINGS = (temp_settings.get('THREAD_TAG'),temp_settings.get('FLAIR'),
+            self.THREAD_SETTINGS = (temp_settings.get('THREAD_TAG'),
                                     (content_settings.get('HEADER'), content_settings.get('BOX_SCORE'),
                                      content_settings.get('LINE_SCORE'), content_settings.get('SCORING_PLAYS'),
-                                     content_settings.get('HIGHLIGHTS'), content_settings.get('FOOTER'), content_settings.get('THEATER_LINK'))
+                                     content_settings.get('HIGHLIGHTS'), content_settings.get('FOOTER'))
                                  )
             if self.THREAD_SETTINGS == None: return "Missing THREAD_SETTINGS"
 
             temp_settings = settings.get('POST_THREAD_SETTINGS')
             content_settings = temp_settings.get('CONTENT')
-            self.POST_THREAD_SETTINGS = (temp_settings.get('POST_THREAD_TAG'), temp_settings.get('FLAIR'), temp_settings.get('POST_THREAD_WIN_TAG'), temp_settings.get('POST_THREAD_LOSS_TAG'), 
+            self.POST_THREAD_SETTINGS = (temp_settings.get('POST_THREAD_TAG'),
                                     (content_settings.get('HEADER'), content_settings.get('BOX_SCORE'),
                                      content_settings.get('LINE_SCORE'), content_settings.get('SCORING_PLAYS'),
-                                     content_settings.get('HIGHLIGHTS'), content_settings.get('FOOTER'), content_settings.get('THEATER_LINK'))
+                                     content_settings.get('HIGHLIGHTS'), content_settings.get('FOOTER'))
                                  )
             if self.POST_THREAD_SETTINGS == None: return "Missing POST_THREAD_SETTINGS"
-            
-            self.WINLOSS_POST_THREAD_TAGS = settings.get('WINLOSS_POST_THREAD_TAGS')
-            if self.WINLOSS_POST_THREAD_TAGS == None: return "Missing WINLOSS_POST_THREAD_TAGS"
 
         return 0
 
@@ -285,27 +281,6 @@ class Bot:
                                 print "Stickying submission..."
                                 sub.mod.sticky()
                                 print "Submission stickied..."
-
-                            if self.FLAIR_MODE == 'submitter':
-                                print "Adding flair to submission as submitter..."
-                                choices = sub.flair.choices()
-                                flairsuccess = False
-                                for p in choices:
-                                    if p['flair_text'] == self.PRE_THREAD_SETTINGS[2]:
-                                        sub.flair.select(p['flair_template_id'])
-                                        flairsuccess = True
-                                if flairsuccess: print "Submission flaired..."
-                                else: print "Flair not set: could not find flair in available choices"
-                            elif self.FLAIR_MODE == 'mod':
-                                print "Adding flair to submission as mod..."
-                                sub.mod.flair(self.PRE_THREAD_SETTINGS[2])
-                                print "Submission flaired..."
-
-                            if self.SUGGESTED_SORT != "":
-                                print "Setting suggested sort to " + self.SUGGESTED_SORT + "..."
-                                sub.mod.suggested_sort(self.SUGGESTED_SORT)
-                                print "Suggested sort set..."
-
                             print "Sleeping for two minutes..."
                             print datetime.strftime(datetime.today(), "%d %I:%M %p")
                             time.sleep(5)
@@ -354,21 +329,6 @@ class Bot:
                                     print "Messaging Baseballbot..."
                                     r.send_message('baseballbot', 'Gamethread posted', sub.short_link)
                                     print "Baseballbot messaged..."
-
-                                if self.FLAIR_MODE == 'submitter':
-                                    print "Adding flair to submission as submitter..."
-                                    choices = sub.flair.choices()
-                                    flairsuccess = False
-                                    for p in choices:
-                                        if p['flair_text'] == self.THREAD_SETTINGS[1]:
-                                            sub.flair.select(p['flair_template_id'])
-                                            flairsuccess = True
-                                    if flairsuccess: print "Submission flaired..."
-                                    else: print "Flair not set: could not find flair in available choices"
-                                elif self.FLAIR_MODE == 'mod':
-                                    print "Adding flair to submission as mod..."
-                                    sub.mod.flair(self.THREAD_SETTINGS[1])
-                                    print "Submission flaired..."
 
                             print "Sleeping for two minutes..."
                             print datetime.strftime(check, "%d %I:%M %p")
@@ -432,7 +392,7 @@ class Bot:
 
                             if self.POST_GAME_THREAD:
                                 print "Submitting postgame thread..."
-                                posttitle = edit.generate_title(d,"post",self.WINLOSS_POST_THREAD_TAGS,self.TEAM_CODE)
+                                posttitle = edit.generate_title(d,"post")
                                 sub = subreddit.submit(posttitle, selftext=edit.generate_code(d,"post"), send_replies=self.INBOXREPLIES)
                                 print "Postgame thread submitted..."
 
@@ -440,27 +400,6 @@ class Bot:
                                     print "Stickying submission..."
                                     sub.mod.sticky()
                                     print "Submission stickied..."
-
-                                if self.FLAIR_MODE == 'submitter':
-                                    print "Adding flair to submission as submitter..."
-                                    choices = sub.flair.choices()
-                                    flairsuccess = False
-                                    for p in choices:
-                                        if p['flair_text'] == self.POST_THREAD_SETTINGS[1]:
-                                            sub.flair.select(p['flair_template_id'])
-                                            flairsuccess = True
-                                    if flairsuccess: print "Submission flaired..."
-                                    else: print "Flair not set: could not find flair in available choices"
-                                elif self.FLAIR_MODE == 'mod':
-                                    print "Adding flair to submission as mod..."
-                                    sub.mod.flair(self.POST_THREAD_SETTINGS[1])
-                                    print "Submission flaired..."
-
-                                if self.SUGGESTED_SORT != "":
-                                    print "Setting suggested sort to " + self.SUGGESTED_SORT + "..."
-                                    sub.mod.suggested_sort(self.SUGGESTED_SORT)
-                                    print "Suggested sort set..."
-
                             time.sleep(10)
                             break
                         else: 

--- a/src/main.py
+++ b/src/main.py
@@ -210,6 +210,10 @@ class Bot:
                                 print "Stickying submission..."
                                 sub.sticky()
                                 print "Submission stickied..."
+                            if self.SUGGESTED_SORT != None:
+                                print "Setting suggested sort to " + self.SUGGESTED_SORT + "..."
+                                sub.set_suggested_sort(self.SUGGESTED_SORT)
+                                print "Suggested sort set..."
                             print "Sleeping for two minutes..."
                             print datetime.strftime(datetime.today(), "%d %I:%M %p")
                             time.sleep(5)
@@ -329,6 +333,11 @@ class Bot:
                                     print "Stickying submission..."
                                     sub.sticky()
                                     print "Submission stickied..."
+                                
+                                if self.SUGGESTED_SORT != None:
+                                    print "Setting suggested sort to " + self.SUGGESTED_SORT + "..."
+                                    sub.set_suggested_sort(self.SUGGESTED_SORT)
+                                    print "Suggested sort set..."
                             time.sleep(10)
                             break
                         else: 

--- a/src/main.py
+++ b/src/main.py
@@ -192,8 +192,8 @@ class Bot:
                 while True:
                     try:
                         posted = False
-                        subreddit = r.subreddit(self.SUBREDDIT).new()
-                        for submission in subreddit:
+                        subreddit = r.subreddit(self.SUBREDDIT)
+                        for submission in subreddit.new():
                             if submission.title == title:
                                 print "Pregame thread already posted, getting submission..."
                                 submission.edit(edit.generate_pre_code(directories))
@@ -203,14 +203,14 @@ class Bot:
                             print "Submitting pregame thread..."
                             if self.STICKY and 'sub' in locals():
                                 try:
-                                    sub.unsticky()
+                                    sub.mod.sticky(state=False)
                                 except Exception, err:
                                     print "Unsticky failed, continuing."
-                            sub = r.submit(self.SUBREDDIT, title, edit.generate_pre_code(directories), send_replies=self.INBOXREPLIES)
+                            sub = subreddit.submit(title, selftext=edit.generate_pre_code(directories), send_replies=self.INBOXREPLIES)
                             print "Pregame thread submitted..."
                             if self.STICKY:
                                 print "Stickying submission..."
-                                sub.sticky()
+                                sub.mod.sticky()
                                 print "Submission stickied..."
                             print "Sleeping for two minutes..."
                             print datetime.strftime(datetime.today(), "%d %I:%M %p")
@@ -228,8 +228,8 @@ class Bot:
                         check = datetime.today()
                         try:
                             posted = False
-                            subreddit = r.subreddit(self.SUBREDDIT).new()
-                            for submission in subreddit:
+                            subreddit = r.subreddit(self.SUBREDDIT)
+                            for submission in subreddit.new():
                                 if submission.title == title:
                                     print "Thread already posted, getting submission..."
                                     sub = submission
@@ -238,22 +238,22 @@ class Bot:
                             if not posted:
                                 if self.STICKY and 'sub' in locals():
                                     try:
-                                        sub.unsticky()
+                                        sub.mod.sticky(state=False)
                                     except Exception, err:
                                         print "Unsticky failed, continuing."
 
                                 print "Submitting game thread..."
-                                sub = r.submit(self.SUBREDDIT, title, edit.generate_code(d,"game"), send_replies=self.INBOXREPLIES)
+                                sub = subreddit.submit(title, selftext=edit.generate_code(d,"game"), send_replies=self.INBOXREPLIES)
                                 print "Game thread submitted..."
 
                                 if self.STICKY:
                                     print "Stickying submission..."
-                                    sub.sticky()
+                                    sub.mod.sticky()
                                     print "Submission stickied..."
 
                                 if self.SUGGESTED_SORT != None:
                                     print "Setting suggested sort to " + self.SUGGESTED_SORT + "..."
-                                    sub.set_suggested_sort(self.SUGGESTED_SORT)
+                                    sub.mod.suggested_sort(self.SUGGESTED_SORT)
                                     print "Suggested sort set..."
 
                                 if self.MESSAGE:
@@ -317,19 +317,19 @@ class Bot:
                         if pgt_submit:
                             if self.STICKY and 'sub' in locals():
                                 try:
-                                    sub.unsticky()
+                                    sub.mod.sticky(state=False)
                                 except Exception, err:
                                     print "Unsticky failed, continuing."
 
                             if self.POST_GAME_THREAD:
                                 print "Submitting postgame thread..."
                                 posttitle = edit.generate_title(d,"post")
-                                sub = r.submit(self.SUBREDDIT, posttitle, edit.generate_code(d,"post"), send_replies=self.INBOXREPLIES)
+                                sub = subreddit.submit(posttitle, selftext=edit.generate_code(d,"post"), send_replies=self.INBOXREPLIES)
                                 print "Postgame thread submitted..."
 
                                 if self.STICKY:
                                     print "Stickying submission..."
-                                    sub.sticky()
+                                    sub.mod.sticky()
                                     print "Submission stickied..."
                             time.sleep(10)
                             break

--- a/src/main.py
+++ b/src/main.py
@@ -333,7 +333,6 @@ class Bot:
                                     print "Stickying submission..."
                                     sub.sticky()
                                     print "Submission stickied..."
-                                
                                 if self.SUGGESTED_SORT != None:
                                     print "Setting suggested sort to " + self.SUGGESTED_SORT + "..."
                                     sub.set_suggested_sort(self.SUGGESTED_SORT)

--- a/src/main.py
+++ b/src/main.py
@@ -36,6 +36,7 @@ class Bot:
         self.SUGGESTED_SORT = None
         self.MESSAGE = None
         self.INBOXREPLIES = None
+        self.FLAIR_MODE = None
         self.PRE_THREAD_SETTINGS = None
         self.THREAD_SETTINGS = None
         self.POST_THREAD_SETTINGS = None
@@ -93,17 +94,21 @@ class Bot:
 
             self.INBOXREPLIES = settings.get('INBOXREPLIES')
             if self.INBOXREPLIES == None: return "Missing INBOXREPLIES"
+            
+            self.FLAIR_MODE = settings.get('FLAIR_MODE')
+            if self.FLAIR_MODE == None: return "Missing FLAIR_MODE"
+            if self.FLAIR_MODE not in ['', 'none', 'submitter', 'mod']: return "Invalid FLAIR_MODE ('none', 'submitter', 'mod')"
 
             temp_settings = settings.get('PRE_THREAD_SETTINGS')
             content_settings = temp_settings.get('CONTENT')
-            self.PRE_THREAD_SETTINGS = (temp_settings.get('PRE_THREAD_TAG'),temp_settings.get('PRE_THREAD_TIME'),
+            self.PRE_THREAD_SETTINGS = (temp_settings.get('PRE_THREAD_TAG'),temp_settings.get('PRE_THREAD_TIME'),temp_settings.get('FLAIR'),
                                             (content_settings.get('PROBABLES'),content_settings.get('FIRST_PITCH'))
                                        )
             if self.PRE_THREAD_SETTINGS == None: return "Missing PRE_THREAD_SETTINGS"
 
             temp_settings = settings.get('THREAD_SETTINGS')
             content_settings = temp_settings.get('CONTENT')
-            self.THREAD_SETTINGS = (temp_settings.get('THREAD_TAG'),
+            self.THREAD_SETTINGS = (temp_settings.get('THREAD_TAG'),temp_settings.get('FLAIR'),
                                     (content_settings.get('HEADER'), content_settings.get('BOX_SCORE'),
                                      content_settings.get('LINE_SCORE'), content_settings.get('SCORING_PLAYS'),
                                      content_settings.get('HIGHLIGHTS'), content_settings.get('FOOTER'))
@@ -112,7 +117,7 @@ class Bot:
 
             temp_settings = settings.get('POST_THREAD_SETTINGS')
             content_settings = temp_settings.get('CONTENT')
-            self.POST_THREAD_SETTINGS = (temp_settings.get('POST_THREAD_TAG'),
+            self.POST_THREAD_SETTINGS = (temp_settings.get('POST_THREAD_TAG'),temp_settings.get('FLAIR'),
                                     (content_settings.get('HEADER'), content_settings.get('BOX_SCORE'),
                                      content_settings.get('LINE_SCORE'), content_settings.get('SCORING_PLAYS'),
                                      content_settings.get('HIGHLIGHTS'), content_settings.get('FOOTER'))
@@ -211,6 +216,20 @@ class Bot:
                                 print "Stickying submission..."
                                 sub.mod.sticky()
                                 print "Submission stickied..."
+                            if self.FLAIR_MODE == 'submitter':
+                                print "Adding flair to submission as submitter..."
+                                choices = sub.flair.choices()
+                                flairsuccess = False
+                                for p in choices:
+                                    if p['flair_text'] == self.PRE_THREAD_SETTINGS[2]:
+                                        sub.flair.select(p['flair_template_id'])
+                                        flairsuccess = True
+                                if flairsuccess: print "Submission flaired..."
+                                else: print "Flair not set: could not find flair in available choices"
+                            elif self.FLAIR_MODE == 'mod':
+                                print "Adding flair to submission as mod..."
+                                sub.mod.flair(self.PRE_THREAD_SETTINGS[2])
+                                print "Submission flaired..."
                             print "Sleeping for two minutes..."
                             print datetime.strftime(datetime.today(), "%d %I:%M %p")
                             time.sleep(5)
@@ -250,7 +269,7 @@ class Bot:
                                     sub.mod.sticky()
                                     print "Submission stickied..."
 
-                                if self.SUGGESTED_SORT != None:
+                                if self.SUGGESTED_SORT != "":
                                     print "Setting suggested sort to " + self.SUGGESTED_SORT + "..."
                                     sub.mod.suggested_sort(self.SUGGESTED_SORT)
                                     print "Suggested sort set..."
@@ -259,6 +278,21 @@ class Bot:
                                     print "Messaging Baseballbot..."
                                     r.send_message('baseballbot', 'Gamethread posted', sub.short_link)
                                     print "Baseballbot messaged..."
+
+                                if self.FLAIR_MODE == 'submitter':
+                                    print "Adding flair to submission as submitter..."
+                                    choices = sub.flair.choices()
+                                    flairsuccess = False
+                                    for p in choices:
+                                        if p['flair_text'] == self.THREAD_SETTINGS[1]:
+                                            sub.flair.select(p['flair_template_id'])
+                                            flairsuccess = True
+                                    if flairsuccess: print "Submission flaired..."
+                                    else: print "Flair not set: could not find flair in available choices"
+                                elif self.FLAIR_MODE == 'mod':
+                                    print "Adding flair to submission as mod..."
+                                    sub.mod.flair(self.THREAD_SETTINGS[1])
+                                    print "Submission flaired..."
 
                             print "Sleeping for two minutes..."
                             print datetime.strftime(check, "%d %I:%M %p")
@@ -330,6 +364,22 @@ class Bot:
                                     print "Stickying submission..."
                                     sub.mod.sticky()
                                     print "Submission stickied..."
+
+                                if self.FLAIR_MODE == 'submitter':
+                                    print "Adding flair to submission as submitter..."
+                                    choices = sub.flair.choices()
+                                    flairsuccess = False
+                                    for p in choices:
+                                        if p['flair_text'] == self.POST_THREAD_SETTINGS[1]:
+                                            sub.flair.select(p['flair_template_id'])
+                                            flairsuccess = True
+                                    if flairsuccess: print "Submission flaired..."
+                                    else: print "Flair not set: could not find flair in available choices"
+                                elif self.FLAIR_MODE == 'mod':
+                                    print "Adding flair to submission as mod..."
+                                    sub.mod.flair(self.POST_THREAD_SETTINGS[1])
+                                    print "Submission flaired..."
+
                             time.sleep(10)
                             break
                         else: 

--- a/src/main.py
+++ b/src/main.py
@@ -250,7 +250,7 @@ class Bot:
                                     sub.mod.sticky()
                                     print "Submission stickied..."
 
-                                if self.SUGGESTED_SORT != None:
+                                if self.SUGGESTED_SORT != "":
                                     print "Setting suggested sort to " + self.SUGGESTED_SORT + "..."
                                     sub.mod.suggested_sort(self.SUGGESTED_SORT)
                                     print "Suggested sort set..."

--- a/src/main.py
+++ b/src/main.py
@@ -217,7 +217,7 @@ class Bot:
                                 print "Submission stickied..."
                             if self.SUGGESTED_SORT != None:
                                 print "Setting suggested sort to " + self.SUGGESTED_SORT + "..."
-                                sub.set_suggested_sort(self.SUGGESTED_SORT)
+                                sub.mod.suggested_sort(self.SUGGESTED_SORT)
                                 print "Suggested sort set..."
                             print "Sleeping for two minutes..."
                             print datetime.strftime(datetime.today(), "%d %I:%M %p")
@@ -340,7 +340,7 @@ class Bot:
                                     print "Submission stickied..."
                                 if self.SUGGESTED_SORT != None:
                                     print "Setting suggested sort to " + self.SUGGESTED_SORT + "..."
-                                    sub.set_suggested_sort(self.SUGGESTED_SORT)
+                                    sub.mod.suggested_sort(self.SUGGESTED_SORT)
                                     print "Suggested sort set..."
                             time.sleep(10)
                             break

--- a/src/main.py
+++ b/src/main.py
@@ -35,6 +35,7 @@ class Bot:
         self.STICKY = None
         self.SUGGESTED_SORT = None
         self.MESSAGE = None
+        self.WINLOSS_POST_THREAD_TAGS = None
         self.INBOXREPLIES = None
         self.PRE_THREAD_SETTINGS = None
         self.THREAD_SETTINGS = None
@@ -109,12 +110,15 @@ class Bot:
 
             temp_settings = settings.get('POST_THREAD_SETTINGS')
             content_settings = temp_settings.get('CONTENT')
-            self.POST_THREAD_SETTINGS = (temp_settings.get('POST_THREAD_TAG'),
+            self.POST_THREAD_SETTINGS = (temp_settings.get('POST_THREAD_TAG'), temp_settings.get('POST_THREAD_WIN_TAG'), temp_settings.get('POST_THREAD_LOSS_TAG'), 
                                     (content_settings.get('HEADER'), content_settings.get('BOX_SCORE'),
                                      content_settings.get('LINE_SCORE'), content_settings.get('SCORING_PLAYS'),
                                      content_settings.get('HIGHLIGHTS'), content_settings.get('FOOTER'))
                                  )
             if self.POST_THREAD_SETTINGS == None: return "Missing POST_THREAD_SETTINGS"
+            
+            self.WINLOSS_POST_THREAD_TAGS = settings.get('WINLOSS_POST_THREAD_TAGS')
+            if self.WINLOSS_POST_THREAD_TAGS == None: return "Missing WINLOSS_POST_THREAD_TAGS"
 
         return 0
 
@@ -321,7 +325,7 @@ class Bot:
 
                             if self.POST_GAME_THREAD:
                                 print "Submitting postgame thread..."
-                                posttitle = edit.generate_title(d,"post")
+                                posttitle = edit.generate_title(d,"post",self.WINLOSS_POST_THREAD_TAGS,self.TEAM_CODE)
                                 sub = r.submit(self.SUBREDDIT, posttitle, edit.generate_code(d,"post"), send_replies=self.INBOXREPLIES)
                                 print "Postgame thread submitted..."
 

--- a/src/main.py
+++ b/src/main.py
@@ -52,6 +52,9 @@ class Bot:
             self.CLIENT_SECRET = settings.get('CLIENT_SECRET')
             if self.CLIENT_SECRET == None: return "Missing CLIENT_SECRET"
 
+            self.USER_AGENT = settings.get('USER_AGENT')
+            if self.USER_AGENT == None: return "Missing USER_AGENT"
+
             self.REDIRECT_URI = settings.get('REDIRECT_URI')
             if self.REDIRECT_URI == None: return "Missing REDIRECT_URI"
 
@@ -126,12 +129,11 @@ class Bot:
             print error_msg
             return
 
-        r = praw.Reddit('OAuth Baseball-GDT-Bot V. 3.0.1'
-                        'https://github.com/mattabullock/Baseball-GDT-Bot')
-        r.set_oauth_app_info(client_id=self.CLIENT_ID,
-                            client_secret=self.CLIENT_SECRET,
-                            redirect_uri=self.REDIRECT_URI)
-        r.refresh_access_information(self.REFRESH_TOKEN)
+        r = praw.Reddit(client_id=self.CLIENT_ID,
+                        client_secret=self.CLIENT_SECRET,
+                        refresh_token=self.REFRESH_TOKEN,
+                        user_agent=self.USER_AGENT)
+        print(r.auth.scopes())
 
         if self.TEAM_TIME_ZONE == 'ET':
             time_info = (self.TEAM_TIME_ZONE,0)
@@ -190,8 +192,8 @@ class Bot:
                 while True:
                     try:
                         posted = False
-                        subreddit = r.get_subreddit(self.SUBREDDIT)
-                        for submission in subreddit.get_new():
+                        subreddit = r.subreddit(self.SUBREDDIT).new()
+                        for submission in subreddit:
                             if submission.title == title:
                                 print "Pregame thread already posted, getting submission..."
                                 submission.edit(edit.generate_pre_code(directories))
@@ -226,8 +228,8 @@ class Bot:
                         check = datetime.today()
                         try:
                             posted = False
-                            subreddit = r.get_subreddit(self.SUBREDDIT)
-                            for submission in subreddit.get_new():
+                            subreddit = r.subreddit(self.SUBREDDIT).new()
+                            for submission in subreddit:
                                 if submission.title == title:
                                     print "Thread already posted, getting submission..."
                                     sub = submission

--- a/src/main.py
+++ b/src/main.py
@@ -133,7 +133,6 @@ class Bot:
                         client_secret=self.CLIENT_SECRET,
                         refresh_token=self.REFRESH_TOKEN,
                         user_agent=self.USER_AGENT)
-        print(r.auth.scopes())
 
         if self.TEAM_TIME_ZONE == 'ET':
             time_info = (self.TEAM_TIME_ZONE,0)

--- a/src/main.py
+++ b/src/main.py
@@ -102,10 +102,6 @@ class Bot:
             self.FLAIR_MODE = settings.get('FLAIR_MODE')
             if self.FLAIR_MODE == None: return "Missing FLAIR_MODE"
             if self.FLAIR_MODE not in ['', 'none', 'submitter', 'mod']: return "Invalid FLAIR_MODE ('none', 'submitter', 'mod')"
-
-            self.FLAIR_MODE = settings.get('FLAIR_MODE')
-            if self.FLAIR_MODE == None: return "Missing FLAIR_MODE"
-            if self.FLAIR_MODE not in ['', 'none', 'submitter', 'mod']: return "Invalid FLAIR_MODE ('none', 'submitter', 'mod')"
             
             temp_settings = settings.get('OFFDAY_THREAD_SETTINGS')
             self.OFFDAY_THREAD_SETTINGS = (temp_settings.get('OFFDAY_THREAD_TAG'),temp_settings.get('OFFDAY_THREAD_TIME'),

--- a/src/main.py
+++ b/src/main.py
@@ -103,7 +103,7 @@ class Bot:
             self.THREAD_SETTINGS = (temp_settings.get('THREAD_TAG'),
                                     (content_settings.get('HEADER'), content_settings.get('BOX_SCORE'),
                                      content_settings.get('LINE_SCORE'), content_settings.get('SCORING_PLAYS'),
-                                     content_settings.get('HIGHLIGHTS'), content_settings.get('FOOTER'))
+                                     content_settings.get('HIGHLIGHTS'), content_settings.get('FOOTER'), content_settings.get('THEATER_LINK'))
                                  )
             if self.THREAD_SETTINGS == None: return "Missing THREAD_SETTINGS"
 
@@ -112,7 +112,7 @@ class Bot:
             self.POST_THREAD_SETTINGS = (temp_settings.get('POST_THREAD_TAG'),
                                     (content_settings.get('HEADER'), content_settings.get('BOX_SCORE'),
                                      content_settings.get('LINE_SCORE'), content_settings.get('SCORING_PLAYS'),
-                                     content_settings.get('HIGHLIGHTS'), content_settings.get('FOOTER'))
+                                     content_settings.get('HIGHLIGHTS'), content_settings.get('FOOTER'), content_settings.get('THEATER_LINK'))
                                  )
             if self.POST_THREAD_SETTINGS == None: return "Missing POST_THREAD_SETTINGS"
 


### PR DESCRIPTION
This is based on the `mb-offday` branch, but has support for PRAW 5, option to configure the offday post body, as well as support for setting suggested sort and flair on the offday thread (pre/game/post thread support for those features are pending in pull requests #32 and #36). This pull request includes changes from #35 to include support for PRAW 5.0.1.